### PR TITLE
feat(launchpad): image-to-image search (#15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .plans/
+.worktrees/
 
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ Output (`collect.json`, abbreviated):
 >     --use-case image-search --dataset-size 64000 --deployment local-standalone
 > ```
 > Phase 1 walks the directory, reads EXIF, encodes a thumbnail per image. Phase 3 then picks `clip-local` (open-source ViT-B/32, runs on CPU/MPS/CUDA, no API key) by default — install the optional extra first: `uv pip install -e '.[multimodal]'`. The Next.js UI auto-switches to a thumbnail gallery. See [issue #14](https://github.com/zilliztech/zilliz-launchpad/issues/14) for the MVP scope.
+>
+> **Search by example (image → image).** After Phase 4 Execute builds the collection you can query with another image instead of a text phrase. In the demo UI (`pnpm dev` from `scripts/ui/`) click **Search by image…** next to the text box — or drop an image anywhere on the page — to find visually similar images in your collection. Uploads are capped at 10 MB per request. For a CLI smoke:
+> ```bash
+> uv run python skills/zilliz-launchpad/scripts/zilliz_ops.py evaluate \
+>     --query-image ./query/my_dog.jpg
+> ```
+> This prints the top-10 ranked primary keys with scores and is the fastest way to confirm image-to-image is wired. For a labelled eval, mix image-to-image rows into your qrels file (one row per line):
+> ```json
+> {"query_image_path": "query/sunset.jpg", "expected_image_ids": ["photos/sky1.jpg", "photos/beach2.jpg"]}
+> ```
+> and pass the file to `evaluate --qrels path/to/qrels.jsonl` to get recall / MRR / NDCG against your ground truth. Queries against a Voyage-multimodal-backed collection (`embedding_preference: voyage-multimodal-3`) call the Voyage API per query and bill to `VOYAGE_API_KEY`; CLIP-local stays free. See [issue #15](https://github.com/zilliztech/zilliz-launchpad/issues/15).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.7",
     "jsonschema>=4.23",
     "fastapi>=0.115",
+    "python-multipart>=0.0.9",
     "uvicorn[standard]>=0.30",
     "openai>=1.40",
     "cohere>=5.10",

--- a/skills/zilliz-launchpad/SKILL.md
+++ b/skills/zilliz-launchpad/SKILL.md
@@ -149,7 +149,7 @@ Known codes and how to react:
 - No Milvus Lite (only Standalone + Zilliz Cloud)
 - No MCP server (the CLI is designed so one can be added later without touching `lib/`)
 - No on-device embedding — API providers only
-- No image-to-image / video — text-to-image only
+- No video — image-to-image supported (CLI `--query-image`, UI upload/drag-and-drop), frame-sampling not yet
 - No IDE integration beyond Claude Code
 
 If the user asks for any of the above, politely say it's on the roadmap and keep scope tight.

--- a/skills/zilliz-launchpad/scripts/lib/errors.py
+++ b/skills/zilliz-launchpad/scripts/lib/errors.py
@@ -186,6 +186,30 @@ class DestructiveWithoutConfirmError(LaunchpadError):
         )
 
 
+class UnsupportedImageProviderError(LaunchpadError):
+    code = "unsupported_image_provider"
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(
+            f"Embedding provider '{provider}' has no image modality; "
+            "re-run plan with an image-capable provider (clip-local or voyage-multimodal-3)",
+            provider=provider,
+        )
+
+
+class ImageDecodeError(LaunchpadError):
+    code = "image_decode_failed"
+
+    SUPPORTED_FORMATS = ["jpg", "jpeg", "png", "webp", "gif"]
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(
+            f"Could not decode upload as a supported image: {reason}",
+            reason=reason,
+            supported_formats=list(self.SUPPORTED_FORMATS),
+        )
+
+
 @dataclass
 class CliErrorEnvelope:
     """Uniform envelope emitted to stderr on failure."""

--- a/skills/zilliz-launchpad/scripts/lib/evaluator.py
+++ b/skills/zilliz-launchpad/scripts/lib/evaluator.py
@@ -34,11 +34,16 @@ class QueryWithExpectedIds:
     still flows through `compute_latency` but is dropped from retrieval math.
     `grade` is an optional graded-relevance value (NDCG uses it; recall/MRR
     treat any appearance as relevant).
+
+    When `query_image_path` is set, the evaluator routes this row through the
+    image→image search path: `query` carries a display label (e.g. the query
+    filename) and the real payload is the bytes at the named path.
     """
 
     query: str
     relevant_ids: tuple[str, ...] = ()
     grade: int = 1
+    query_image_path: str | None = None
 
 
 # --- Retrieval metrics ------------------------------------------------------

--- a/skills/zilliz-launchpad/scripts/lib/phases/evaluate.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/evaluate.py
@@ -33,7 +33,7 @@ from ..evaluator import (
     derive_queries_from_corpus,
 )
 from ..run_dir import load_plan, preflight_execute_artifact
-from ..search import search_dense, search_hybrid
+from ..search import search_dense, search_hybrid, search_image_to_image
 from ..vision_judge import caption_images, is_vision_capable
 from .execute import _iter_documents
 
@@ -130,6 +130,45 @@ def run_evaluate(
     return report
 
 
+# --- Query-image smoke -----------------------------------------------------
+
+
+def run_query_image_smoke(
+    *,
+    out_dir: Path,
+    query_image_path: str,
+    top_k: int = _TOP_K,
+) -> list[dict[str, Any]]:
+    """Smoke path: encode a query image, return top-k hits, skip metrics.
+
+    Writes nothing to disk. The CLI formats the returned rows for stdout.
+    """
+    preflight_execute_artifact(out_dir)
+    plan = load_plan(out_dir)
+    if not _is_image_plan(plan):
+        raise InvalidProfileError(
+            pointer="cli",
+            reason="--query-image requires an image collection; this run is text-only",
+        )
+    path = Path(query_image_path)
+    if not path.exists():
+        raise InvalidProfileError(pointer=str(path), reason="query image file not found")
+    image_bytes = path.read_bytes()
+
+    client = MilvusClient(uri=plan["target_uri"])
+    schema = plan["schema"]
+    hits = search_image_to_image(
+        client,
+        plan["collection_name"],
+        image_bytes,
+        plan,
+        top_k=top_k,
+        vector_field=schema["vector_field"],
+        output_fields=[schema["primary_key"]],
+    )
+    return [{"id": h.id, "score": h.score} for h in hits]
+
+
 # --- Query-set resolution --------------------------------------------------
 
 
@@ -164,10 +203,13 @@ def _resolve_query_set(
 
 
 def _load_image_qrels(path: Path) -> list[QueryWithExpectedIds]:
-    """Image qrels rows: `{query_text, image_path}`.
+    """Image qrels loader. Accepts two row shapes, possibly mixed in one file:
 
-    `image_path` is the collection's primary key, so we map it directly to
-    the existing `relevant_ids` shape — no separate image-aware metric path.
+    - Text→image: `{query_text, image_paths}` (existing)
+    - Image→image: `{query_image_path, expected_image_ids}` (new in #15)
+
+    `image_paths` / `expected_image_ids` become the collection's primary keys,
+    so both rows land in `relevant_ids` and share the downstream metric path.
     """
     if not path.exists():
         raise InvalidProfileError(pointer=str(path), reason="qrels file not found")
@@ -183,27 +225,57 @@ def _load_image_qrels(path: Path) -> list[QueryWithExpectedIds]:
                 raise InvalidProfileError(
                     pointer=f"{path}:{lineno}", reason=f"invalid JSON: {exc}"
                 ) from exc
-            query = record.get("query_text") or record.get("query")
-            paths = record.get("image_paths") or record.get("image_path")
-            if isinstance(paths, str):
-                paths = [paths]
             grade = int(record.get("grade") or 1)
-            if not isinstance(query, str) or not query.strip():
-                raise InvalidProfileError(
-                    pointer=f"{path}:{lineno}",
-                    reason="missing 'query_text' (or 'query') string",
+            query_image_path = record.get("query_image_path")
+            query_text = record.get("query_text") or record.get("query")
+
+            if query_image_path:
+                relevant = (
+                    record.get("expected_image_ids")
+                    or record.get("expected_image_paths")
+                    or record.get("image_paths")
                 )
-            if not paths or not isinstance(paths, list):
-                raise InvalidProfileError(
-                    pointer=f"{path}:{lineno}",
-                    reason="missing 'image_path' / 'image_paths' value",
+                if isinstance(relevant, str):
+                    relevant = [relevant]
+                if not relevant or not isinstance(relevant, list):
+                    raise InvalidProfileError(
+                        pointer=f"{path}:{lineno}",
+                        reason=("image→image row missing 'expected_image_ids' list"),
+                    )
+                out.append(
+                    QueryWithExpectedIds(
+                        query=str(query_image_path),
+                        relevant_ids=tuple(str(p) for p in relevant),
+                        grade=grade,
+                        query_image_path=str(query_image_path),
+                    )
                 )
-            out.append(
-                QueryWithExpectedIds(
-                    query=query.strip(),
-                    relevant_ids=tuple(str(p) for p in paths),
-                    grade=grade,
+                continue
+
+            if query_text:
+                paths = record.get("image_paths") or record.get("image_path")
+                if isinstance(paths, str):
+                    paths = [paths]
+                if not paths or not isinstance(paths, list):
+                    raise InvalidProfileError(
+                        pointer=f"{path}:{lineno}",
+                        reason="missing 'image_path' / 'image_paths' value",
+                    )
+                out.append(
+                    QueryWithExpectedIds(
+                        query=str(query_text).strip(),
+                        relevant_ids=tuple(str(p) for p in paths),
+                        grade=grade,
+                    )
                 )
+                continue
+
+            raise InvalidProfileError(
+                pointer=f"{path}:{lineno}",
+                reason=(
+                    "qrels row must carry 'query_text' (text→image) or "
+                    "'query_image_path' (image→image)"
+                ),
             )
     return out
 
@@ -441,10 +513,13 @@ def _evaluate_single_image(
     queries: Sequence[QueryWithExpectedIds],
     concurrency: int,
 ) -> dict[str, Any]:
-    """Image-flow eval: encode queries via CLIP text, dense search, score.
+    """Image-flow eval: route text queries via CLIP-text, image queries via
+    the image-to-image path.
 
     No RAG metrics (no text corpus to ground answers in). No hybrid (image
-    collections always have sparse disabled).
+    collections always have sparse disabled). Queries whose `query_image_path`
+    points at a missing file are skipped with a stderr warning and drop out
+    of retrieval math; latency timing still runs over the surviving rows.
     """
     client = MilvusClient(uri=plan["target_uri"])
     collection = plan["collection_name"]
@@ -456,20 +531,42 @@ def _evaluate_single_image(
     device_hint = embedding.get("device_hint")
     provider = str(embedding["provider"]).lower()
 
-    if provider != "clip-local":
-        # Voyage multimodal query encoding lives behind its own API call;
-        # the MVP scope (issue #14) gates evaluate on clip-local. Surface a
-        # clean error rather than silently producing wrong vectors.
+    has_text_queries = any(q.query_image_path is None for q in queries)
+    if provider != "clip-local" and has_text_queries:
+        # Voyage multimodal query encoding for text lives behind its own API
+        # call; the MVP scope (#14) gates evaluate on clip-local for text rows.
         raise BackendUnsupportedError(
             uri=provider,
-            feature="image-evaluate currently supports clip-local only (Voyage TODO)",
+            feature="image-evaluate text queries currently require clip-local (Voyage TODO)",
         )
 
-    def _encode(text: str) -> list[float]:
+    # Cache image-query embeddings so the same query file isn't re-encoded
+    # when it appears in multiple qrels rows within one run.
+    image_vec_cache: dict[str, list[float]] = {}
+    skipped_missing: list[str] = []
+
+    def _encode_text(text: str) -> list[float]:
         return embed_text_with_clip([text], model_id=model_id, device_hint=device_hint)[0]
 
-    def _search(q: str) -> list[str]:
-        qvec = _encode(q)
+    def _encode_image(query_image_path: str) -> list[float] | None:
+        cached = image_vec_cache.get(query_image_path)
+        if cached is not None:
+            return cached
+        p = Path(query_image_path)
+        if not p.exists():
+            logger.warning(
+                "eval: skipping image-to-image row — query image not found: %s",
+                query_image_path,
+            )
+            skipped_missing.append(query_image_path)
+            return None
+        from ..search import _encode_query_image
+
+        vec = _encode_query_image(p.read_bytes(), plan)
+        image_vec_cache[query_image_path] = vec
+        return vec
+
+    def _run_search(qvec: list[float]) -> list[str]:
         res = client.search(
             collection_name=collection,
             data=[qvec],
@@ -489,14 +586,48 @@ def _evaluate_single_image(
                 ids.append(str(pk_val) if pk_val else "")
         return ids
 
+    def _search_one(q: QueryWithExpectedIds) -> list[str]:
+        if q.query_image_path:
+            vec = _encode_image(q.query_image_path)
+            if vec is None:
+                return []
+            return _run_search(vec)
+        return _run_search(_encode_text(q.query))
+
+    survivors: list[QueryWithExpectedIds] = []
     ranked_ids: list[list[str]] = []
     for q in queries:
-        ranked_ids.append(_search(q.query))
+        hits = _search_one(q)
+        if q.query_image_path and not hits and q.query_image_path in skipped_missing:
+            continue  # dropped entirely; no contribution to metrics or latency
+        survivors.append(q)
+        ranked_ids.append(hits)
 
-    retrieval = compute_retrieval_metrics(queries, ranked_ids, k=_TOP_K)
-    latency = compute_latency(_search, [q.query for q in queries], concurrency=concurrency)
+    retrieval = compute_retrieval_metrics(survivors, ranked_ids, k=_TOP_K)
+    # Latency uses a bytes-and-text agnostic lambda so concurrency timing
+    # exercises both routing branches that a caller actually hits.
+    latency = compute_latency(
+        lambda label_str: _search_one(_query_by_label(survivors, label_str)),
+        [_label_for(q) for q in survivors],
+        concurrency=concurrency,
+    )
     row = _RowResult(label=label, retrieval=retrieval, latency=latency, rag=None)
-    return row.to_dict()
+    out = row.to_dict()
+    if skipped_missing:
+        out["skipped_queries"] = list(skipped_missing)
+    return out
+
+
+def _label_for(q: QueryWithExpectedIds) -> str:
+    return q.query_image_path or q.query
+
+
+def _query_by_label(queries: Sequence[QueryWithExpectedIds], label: str) -> QueryWithExpectedIds:
+    for q in queries:
+        if _label_for(q) == label:
+            return q
+    # Fallback — shouldn't happen because labels come from the same list
+    return queries[0]
 
 
 def _search_only_timing(search_fn: Callable[[str], Any]) -> Callable[[str], Any]:
@@ -675,7 +806,7 @@ def _build_report(
     variant_rows: list[dict[str, Any]],
     derived: bool,
 ) -> dict[str, Any]:
-    return {
+    report: dict[str, Any] = {
         "derived": derived,
         "latency_metrics": base_row["latency"],
         "query_count": len(queries),
@@ -685,6 +816,10 @@ def _build_report(
         "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
         "variants": variant_rows,
     }
+    if base_row.get("skipped_queries"):
+        report["skipped_queries"] = list(base_row["skipped_queries"])
+        report["skipped_count"] = len(base_row["skipped_queries"])
+    return report
 
 
 def _write_report(out_dir: Path, report: dict[str, Any]) -> None:

--- a/skills/zilliz-launchpad/scripts/lib/search.py
+++ b/skills/zilliz-launchpad/scripts/lib/search.py
@@ -9,8 +9,8 @@ from typing import Any, Literal
 from pymilvus import MilvusClient
 
 from .credentials import resolve_required
-from .embeddings import EmbeddingProvider
-from .errors import SparseUnavailable
+from .embeddings import EmbeddingProvider, embed_image_batch, embed_image_batch_voyage
+from .errors import ImageDecodeError, SparseUnavailable, UnsupportedImageProviderError
 
 FusionMode = Literal["rrf", "weighted"]
 Mode = Literal["dense", "sparse", "hybrid"]
@@ -64,6 +64,79 @@ def search_dense(
     hits = _hits_from_milvus(raw[0]) if raw else []
     if rerank:
         hits = apply_reranker(rerank, query_text, hits)[:top_k]
+    return hits[:top_k]
+
+
+_IMAGE_PROVIDERS = frozenset({"clip-local", "voyage"})
+
+
+def _encode_query_image(image_bytes: bytes, plan: dict[str, Any]) -> list[float]:
+    """Encode raw image bytes into a query vector matching the plan's provider.
+
+    Writes bytes to a NamedTemporaryFile so the existing path-based encoders
+    in `embeddings.py` can be reused without change. The file is unlinked on
+    exit of the `with` block regardless of exception paths.
+    """
+    import tempfile
+
+    embedding = plan.get("embedding") or {}
+    provider = str(embedding.get("provider") or "").lower()
+    if provider not in _IMAGE_PROVIDERS:
+        raise UnsupportedImageProviderError(provider or "(none)")
+    if provider == "voyage" and str(embedding.get("modality") or "") != "image":
+        raise UnsupportedImageProviderError(str(embedding.get("provider")))
+
+    with tempfile.NamedTemporaryFile(suffix=".img", delete=True) as tmp:
+        tmp.write(image_bytes)
+        tmp.flush()
+        try:
+            if provider == "clip-local":
+                model_id = str(embedding.get("model") or "ViT-B-32")
+                device_hint = embedding.get("device_hint")
+                vecs = embed_image_batch([tmp.name], model_id=model_id, device_hint=device_hint)
+            else:
+                model_id = str(embedding.get("model") or "voyage-multimodal-3")
+                vecs = embed_image_batch_voyage([tmp.name], model_id=model_id)
+        except UnsupportedImageProviderError:
+            raise
+        except Exception as exc:
+            # Pillow's UnidentifiedImageError, Voyage API errors, torch failures —
+            # they all mean we could not turn these bytes into a usable query vector.
+            raise ImageDecodeError(str(exc)) from exc
+
+    if not vecs:
+        raise ImageDecodeError("encoder returned no vector")
+    return list(vecs[0])
+
+
+def search_image_to_image(
+    client: MilvusClient,
+    collection: str,
+    image_bytes: bytes,
+    plan: dict[str, Any],
+    *,
+    top_k: int = 10,
+    vector_field: str = "embedding",
+    filter: str | None = None,
+    output_fields: Sequence[str] | None = None,
+) -> list[Hit]:
+    """Dense-search the image collection using another image as the query.
+
+    The query image is encoded with whatever provider the plan recorded at
+    ingest time — query vectors must live in the same embedding space as the
+    stored vectors, so we read the provider/model/device_hint from `plan`
+    rather than the environment.
+    """
+    vec = _encode_query_image(image_bytes, plan)
+    raw = client.search(
+        collection_name=collection,
+        data=[vec],
+        anns_field=vector_field,
+        limit=top_k,
+        filter=filter or "",
+        output_fields=list(output_fields) if output_fields else None,
+    )
+    hits = _hits_from_milvus(raw[0]) if raw else []
     return hits[:top_k]
 
 

--- a/skills/zilliz-launchpad/scripts/lib/ui.py
+++ b/skills/zilliz-launchpad/scripts/lib/ui.py
@@ -11,14 +11,22 @@ import os
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
 from .client import MilvusClient
-from .embeddings import embed_text_with_clip, make_embedder
-from .errors import LaunchpadError, SparseUnavailable
-from .search import search_dense, search_hybrid, search_sparse
+from .embeddings import embed_image_batch, embed_text_with_clip, make_embedder
+from .errors import (
+    ImageDecodeError,
+    LaunchpadError,
+    SparseUnavailable,
+    UnsupportedImageProviderError,
+)
+from .search import search_dense, search_hybrid, search_image_to_image, search_sparse
+
+MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MiB cap documented in design.md
+_SEARCH_IMAGE_TOP_K_MAX = 100
 
 app = FastAPI(title="zilliz-launchpad sidecar")
 
@@ -206,6 +214,133 @@ def search(req: SearchRequest) -> SearchResponse:
         modality="text",
         hits=[Hit(id=h.id, score=h.score, fields=h.fields) for h in hits],
     )
+
+
+class EmbedImageResponse(BaseModel):
+    embedding: list[float]
+    dim: int
+
+
+def _require_image_collection() -> None:
+    if not _is_image():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "not_image_collection",
+                "message": "This endpoint requires an image collection; active plan is text-only.",
+            },
+        )
+
+
+def _read_upload(file: UploadFile) -> bytes:
+    """Read an UploadFile into memory, enforcing the 10 MB cap.
+
+    We buffer in 1 MB chunks and bail the moment the running total would
+    exceed the limit — keeps a hostile 10 GB upload from pinning memory.
+    """
+    buf = bytearray()
+    chunk_size = 1 << 20
+    while True:
+        chunk = file.file.read(chunk_size)
+        if not chunk:
+            break
+        buf.extend(chunk)
+        if len(buf) > MAX_IMAGE_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "code": "upload_too_large",
+                    "message": f"Upload exceeds {MAX_IMAGE_UPLOAD_BYTES} byte cap",
+                    "max_bytes": MAX_IMAGE_UPLOAD_BYTES,
+                },
+            )
+    return bytes(buf)
+
+
+def _encode_upload(image_bytes: bytes) -> list[float]:
+    """Encode via the already-loaded CLIP model (or Voyage for that plan)."""
+    plan = _plan()
+    embedding = plan.get("embedding") or {}
+    provider = str(embedding.get("provider") or "").lower()
+    if provider == "clip-local":
+        import tempfile
+
+        model_id = str(embedding.get("model") or "ViT-B-32")
+        device_hint = embedding.get("device_hint")
+        with tempfile.NamedTemporaryFile(suffix=".img", delete=True) as tmp:
+            tmp.write(image_bytes)
+            tmp.flush()
+            try:
+                vecs = embed_image_batch([tmp.name], model_id=model_id, device_hint=device_hint)
+            except Exception as exc:
+                raise ImageDecodeError(str(exc)) from exc
+        if not vecs:
+            raise ImageDecodeError("encoder returned no vector")
+        return list(vecs[0])
+    # Voyage + any other image-capable provider share the path via search.py;
+    # delegate there so the provider-routing logic stays in one place.
+    from .search import _encode_query_image
+
+    return _encode_query_image(image_bytes, plan)
+
+
+@app.post("/embed_image", response_model=EmbedImageResponse)
+def embed_image(file: UploadFile = File(...)) -> EmbedImageResponse:  # noqa: B008
+    _require_image_collection()
+    raw = _read_upload(file)
+    try:
+        vec = _encode_upload(raw)
+    except UnsupportedImageProviderError as e:
+        raise HTTPException(status_code=400, detail=e.to_dict()) from e
+    except ImageDecodeError as e:
+        raise HTTPException(status_code=400, detail=e.to_dict()) from e
+    except LaunchpadError as e:
+        raise HTTPException(status_code=400, detail=e.to_dict()) from e
+    return EmbedImageResponse(embedding=vec, dim=len(vec))
+
+
+@app.post("/search_image", response_model=SearchResponse)
+def search_image(
+    file: UploadFile = File(...),  # noqa: B008
+    top_k: int = Form(default=10),  # noqa: B008
+) -> SearchResponse:
+    _require_image_collection()
+    k = max(1, min(_SEARCH_IMAGE_TOP_K_MAX, int(top_k)))
+    raw = _read_upload(file)
+
+    plan = _plan()
+    client = _client()
+    pk = plan["schema"]["primary_key"]
+    vector_field = plan["schema"]["vector_field"]
+
+    try:
+        hits = search_image_to_image(
+            client,
+            plan["collection_name"],
+            raw,
+            plan,
+            top_k=k,
+            vector_field=vector_field,
+            output_fields=[pk],
+        )
+    except UnsupportedImageProviderError as e:
+        raise HTTPException(status_code=400, detail=e.to_dict()) from e
+    except ImageDecodeError as e:
+        raise HTTPException(status_code=400, detail=e.to_dict()) from e
+    except LaunchpadError as e:
+        raise HTTPException(status_code=400, detail=e.to_dict()) from e
+
+    thumbs = _thumbnails()
+    out: list[Hit] = []
+    for h in hits:
+        path = str(h.fields.get(pk, h.id))
+        row = thumbs.get(path) or {}
+        fields: dict[str, Any] = {pk: path}
+        for key in ("thumbnail_b64", "width", "height", "bytes", "taken_at"):
+            if key in row:
+                fields[key] = row[key]
+        out.append(Hit(id=path, score=h.score, fields=fields))
+    return SearchResponse(mode="dense", modality="image", hits=out)
 
 
 def _image_search(req: SearchRequest) -> SearchResponse:

--- a/skills/zilliz-launchpad/scripts/ui/app/page.tsx
+++ b/skills/zilliz-launchpad/scripts/ui/app/page.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { fetchInfo, searchSidecar, SearchMode, type Hit, type InfoResponse } from "@/lib/milvus-client";
+import { useEffect, useRef, useState } from "react";
+import {
+  ACCEPTED_IMAGE_MIME_TYPES,
+  fetchInfo,
+  searchSidecar,
+  searchSidecarImage,
+  SearchMode,
+  type Hit,
+  type InfoResponse,
+} from "@/lib/milvus-client";
 import { ImageGrid } from "./components/ImageGrid";
+
+const ACCEPT_ATTR = ACCEPTED_IMAGE_MIME_TYPES.join(",");
 
 export default function HomePage() {
   const [info, setInfo] = useState<InfoResponse | null>(null);
@@ -13,7 +23,11 @@ export default function HomePage() {
   const [hits, setHits] = useState<Hit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [lastQueryImage, setLastQueryImage] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
+  const [isDropping, setIsDropping] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     fetchInfo()
@@ -38,8 +52,66 @@ export default function HomePage() {
     }
   }
 
+  async function runImageSearch(file: File) {
+    // Client-side MIME guard: the sidecar rejects decode failures with 400,
+    // but catching non-images here avoids a pointless round-trip.
+    const mimeOk = (ACCEPTED_IMAGE_MIME_TYPES as readonly string[]).includes(file.type);
+    if (!mimeOk) {
+      setUploadError(
+        `Unsupported file type: ${file.type || "unknown"}. Supported: JPEG, PNG, WebP, GIF.`,
+      );
+      return;
+    }
+    setUploadError(null);
+    setLoading(true);
+    try {
+      const resp = await searchSidecarImage(file, topK);
+      setHits(resp.hits);
+      setHasSearched(true);
+      setLastQueryImage(file.name);
+    } catch (err: unknown) {
+      // Sidecar error: show inline, keep existing grid visible.
+      setUploadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleFilePicked(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      void runImageSearch(file);
+    }
+    // Clear the input so picking the same file twice still fires change.
+    e.target.value = "";
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLElement>) {
+    e.preventDefault();
+    setIsDropping(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      void runImageSearch(file);
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLElement>) {
+    e.preventDefault();
+    if (!isDropping) setIsDropping(true);
+  }
+
+  function handleDragLeave(e: React.DragEvent<HTMLElement>) {
+    e.preventDefault();
+    setIsDropping(false);
+  }
+
   return (
-    <main style={{ maxWidth: isImage ? 1100 : 800, margin: "2rem auto", padding: "0 1rem" }}>
+    <main
+      style={{ maxWidth: isImage ? 1100 : 800, margin: "2rem auto", padding: "0 1rem" }}
+      onDragOver={isImage ? handleDragOver : undefined}
+      onDragLeave={isImage ? handleDragLeave : undefined}
+      onDrop={isImage ? handleDrop : undefined}
+    >
       <h1 style={{ fontSize: "1.75rem" }}>zilliz-launchpad</h1>
       <p style={{ color: "#888" }}>
         {isImage
@@ -54,14 +126,14 @@ export default function HomePage() {
 
       <form
         onSubmit={handleSubmit}
-        style={{ display: "flex", gap: "0.5rem", marginTop: "1rem" }}
+        style={{ display: "flex", gap: "0.5rem", marginTop: "1rem", flexWrap: "wrap" }}
       >
         <input
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={isImage ? "Describe an image…" : "Ask something…"}
-          style={{ flex: 1 }}
+          style={{ flex: 1, minWidth: 200 }}
           required
         />
         {!isImage && (
@@ -82,7 +154,43 @@ export default function HomePage() {
         <button type="submit" disabled={loading}>
           {loading ? "…" : "Search"}
         </button>
+        {isImage && (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPT_ATTR}
+              onChange={handleFilePicked}
+              style={{ display: "none" }}
+              aria-label="Upload query image"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={loading}
+              title="Search by example image"
+            >
+              Search by image…
+            </button>
+          </>
+        )}
       </form>
+
+      {isImage && (
+        <div style={{ marginTop: "0.75rem", display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+          <p style={{ color: isDropping ? "#38bdf8" : "#555", fontSize: "0.85rem" }}>
+            {isDropping ? "Drop image to search" : "Tip: drop an image anywhere on this page to search by example"}
+          </p>
+          {lastQueryImage && !uploadError && (
+            <p style={{ color: "#888", fontSize: "0.85rem" }}>
+              Last image query: <code>{lastQueryImage}</code>
+            </p>
+          )}
+          {uploadError && (
+            <p style={{ color: "#f87171", fontSize: "0.85rem" }}>{uploadError}</p>
+          )}
+        </div>
+      )}
 
       {isImage ? (
         <ImageGrid hits={hits} loading={loading} error={error} hasSearched={hasSearched} />

--- a/skills/zilliz-launchpad/scripts/ui/lib/milvus-client.ts
+++ b/skills/zilliz-launchpad/scripts/ui/lib/milvus-client.ts
@@ -62,3 +62,41 @@ export async function fetchInfo(): Promise<InfoResponse> {
   }
   return (await resp.json()) as InfoResponse;
 }
+
+export const ACCEPTED_IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export async function searchSidecarImage(
+  file: File,
+  topK = 10,
+): Promise<SearchResponse> {
+  const form = new FormData();
+  form.append("file", file);
+  form.append("top_k", String(topK));
+  const resp = await fetch(`${BASE}/search_image`, {
+    method: "POST",
+    body: form,
+  });
+  if (!resp.ok) {
+    // FastAPI wraps typed errors under `.detail.message`; fall back to raw
+    // text for transport-level failures (413 size cap, CORS, network).
+    let message = `Sidecar /search_image ${resp.status}`;
+    try {
+      const body = (await resp.json()) as { detail?: { message?: string } };
+      if (body?.detail?.message) {
+        message = body.detail.message;
+      }
+    } catch {
+      const text = await resp.text();
+      if (text) {
+        message = `${message}: ${text}`;
+      }
+    }
+    throw new Error(message);
+  }
+  return (await resp.json()) as SearchResponse;
+}

--- a/skills/zilliz-launchpad/scripts/zilliz_ops.py
+++ b/skills/zilliz-launchpad/scripts/zilliz_ops.py
@@ -24,7 +24,7 @@ import sys
 from pathlib import Path
 
 import typer
-from lib.errors import CliErrorEnvelope, LaunchpadError
+from lib.errors import CliErrorEnvelope, InvalidProfileError, LaunchpadError
 from lib.phases import collect as phase_collect
 from lib.phases import configure as phase_configure
 from lib.phases import deploy as phase_deploy
@@ -187,6 +187,11 @@ def evaluate(
     run_dir: str | None = typer.Option(None, "--run-dir"),
     qrels: Path | None = typer.Option(None, "--qrels", help="JSONL with {query, relevant_ids[]}"),  # noqa: B008
     queries: Path | None = typer.Option(None, "--queries", help="Plain query list, one per line"),  # noqa: B008
+    query_image: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--query-image",
+        help="Image collections only: run a one-shot similarity smoke and print top-k",
+    ),
     concurrency: int = typer.Option(1, "--concurrency", min=1, max=64),
     judge_llm: str | None = typer.Option(
         None, "--judge-llm", help="<provider>:<model> — enables ragas metrics"
@@ -198,6 +203,28 @@ def evaluate(
 ) -> None:
     """Phase 5 — score retrieval/latency/RAG quality against the live collection."""
     out = resolve_run_dir(run_dir)
+    if query_image is not None and qrels is not None:
+        _fail(
+            InvalidProfileError(
+                pointer="cli",
+                reason="--query-image is a smoke tool and cannot be combined with --qrels",
+            )
+        )
+    if query_image is not None:
+        try:
+            rows = phase_evaluate.run_query_image_smoke(
+                out_dir=out, query_image_path=str(query_image)
+            )
+        except LaunchpadError as e:
+            _fail(e)
+        typer.echo(f"run-dir: {out}")
+        typer.echo(f"query-image: {query_image}")
+        if not rows:
+            typer.echo("(no hits)")
+            return
+        for rank, row in enumerate(rows, start=1):
+            typer.echo(f"  {rank:>2}. score={row['score']:.4f}  {row['id']}")
+        return
     try:
         report = phase_evaluate.run_evaluate(
             out_dir=out,

--- a/tests/manual/image_upload.md
+++ b/tests/manual/image_upload.md
@@ -1,0 +1,56 @@
+# Manual smoke — image upload in the demo UI
+
+The Next.js UI is excluded from automated pytest/mypy coverage and the drag-and-drop behaviour only exercises the full stack in a real browser. This checklist is the humans-only path.
+
+## Preconditions
+
+- An image-search run directory with a populated collection. Quickest way:
+  ```bash
+  uv run python -m zilliz_launchpad.cli collect --input ./tests/fixtures/photos/ --use-case image-search --dataset-size 20 --deployment local-standalone
+  # …configure / plan / execute — see README "Image search" walkthrough
+  ```
+- CLIP weights pre-fetched (`uv run python -c "from lib.embeddings import prefetch_clip; prefetch_clip()"`).
+- An extra query image on disk — ideally something visually similar to but distinct from the ingested set (e.g. a different dog photo if the corpus is dogs).
+
+## Steps
+
+1. **Start the sidecar** pointed at the run dir:
+   ```bash
+   LAUNCHPAD_RUN_DIR=./runs/<id> uv run uvicorn lib.ui:app --port 8000
+   ```
+   Expect `/health` to return `{"status":"ok", ...}`. Expect `/info` to return `modality: "image"` and a non-null `embedding.model`.
+
+2. **Start the Next.js dev server**:
+   ```bash
+   cd skills/zilliz-launchpad/scripts/ui && pnpm dev
+   ```
+   Open `http://localhost:3000` in a browser.
+
+3. **Verify the upload control appears.** The heading should read `Image search — <collection>` and a `Search by image…` button should be visible next to `Search`. A tip line reads `Tip: drop an image anywhere on this page…`.
+
+4. **File-picker path.** Click `Search by image…`, pick the query image. Expect:
+   - The spinner shows `…` on the Search button briefly.
+   - The result grid updates with ranked thumbnails.
+   - A `Last image query: <filename>` line appears under the form.
+   - No error message is shown.
+
+5. **Drag-and-drop path.** Drag the same image from Finder/Explorer onto the page. Expect:
+   - While dragging, the tip text switches to `Drop image to search` in a lighter blue colour.
+   - On drop, results update identically to the picker path.
+
+6. **Non-image rejection.** Drag a `.txt` or `.pdf` onto the page. Expect:
+   - An inline red error: `Unsupported file type: …`.
+   - The grid stays unchanged (still shows the previous image query results).
+   - No network call is made (check the Network tab — `/search_image` should NOT be hit).
+
+7. **Oversize upload.** If easy to produce, pick a >10 MB image. Expect:
+   - Red inline error with the 10 MB cap message from the sidecar.
+   - The previous grid remains visible.
+
+8. **Text search still works.** With the image run active, type a text query (e.g., "sunset") into the text input and click `Search`. The existing text-to-image path should work unchanged.
+
+## Rollback / cleanup
+
+- Stop dev server: Ctrl-C in the pnpm window.
+- Stop sidecar: Ctrl-C in the uvicorn window.
+- Collection and run dir persist — re-use them for the CLI `evaluate --query-image` smoke in §4.

--- a/tests/test_evaluate_image_qrels.py
+++ b/tests/test_evaluate_image_qrels.py
@@ -1,0 +1,235 @@
+"""Image-to-image qrels loader and evaluation — Phase 5.
+
+Covers the extended qrels shape introduced by issue #15: mixed text→image
+and image→image rows in one file, missing-file skip behaviour, typed
+error for malformed rows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from lib.errors import InvalidProfileError
+from lib.evaluator import QueryWithExpectedIds
+from lib.phases.evaluate import (
+    _evaluate_single_image,
+    _load_image_qrels,
+)
+
+IMAGE_PLAN = {
+    "collection_name": "img_demo",
+    "target_uri": "http://localhost:19530",
+    "schema": {
+        "primary_key": "image_path",
+        "vector_field": "embedding",
+        "text_field": None,
+        "sparse_field": None,
+        "dim": 512,
+    },
+    "embedding": {
+        "provider": "clip-local",
+        "model": "ViT-B-32",
+        "dim": 512,
+        "modality": "image",
+        "device_hint": "cpu",
+    },
+    "sparse_enabled": False,
+}
+
+
+def _fake_hit(pk: str, score: float):
+    hit = MagicMock()
+    hit.id = pk
+    hit.score = score
+    hit.entity = {"image_path": pk}
+    return hit
+
+
+# --- Loader ----------------------------------------------------------------
+
+
+def test_loader_parses_pure_image_to_image_qrels(tmp_path: Path):
+    query_img = tmp_path / "query.jpg"
+    query_img.write_bytes(b"\xff\xd8")
+    qrels = tmp_path / "qrels.jsonl"
+    qrels.write_text(
+        json.dumps(
+            {
+                "query_image_path": str(query_img),
+                "expected_image_ids": ["/photos/a.jpg", "/photos/b.jpg"],
+                "grade": 2,
+            }
+        )
+        + "\n"
+    )
+    rows = _load_image_qrels(qrels)
+    assert len(rows) == 1
+    assert rows[0].query_image_path == str(query_img)
+    assert rows[0].relevant_ids == ("/photos/a.jpg", "/photos/b.jpg")
+    assert rows[0].grade == 2
+
+
+def test_loader_parses_mixed_text_and_image_rows(tmp_path: Path):
+    query_img = tmp_path / "query.jpg"
+    query_img.write_bytes(b"\xff\xd8")
+    qrels = tmp_path / "qrels.jsonl"
+    qrels.write_text(
+        "\n".join(
+            [
+                json.dumps({"query_text": "sunset", "image_paths": ["a.jpg"]}),
+                json.dumps(
+                    {
+                        "query_image_path": str(query_img),
+                        "expected_image_ids": ["b.jpg"],
+                    }
+                ),
+            ]
+        )
+    )
+    rows = _load_image_qrels(qrels)
+    assert len(rows) == 2
+    assert rows[0].query_image_path is None
+    assert rows[0].relevant_ids == ("a.jpg",)
+    assert rows[1].query_image_path == str(query_img)
+    assert rows[1].relevant_ids == ("b.jpg",)
+
+
+def test_loader_rejects_row_with_neither_key(tmp_path: Path):
+    qrels = tmp_path / "qrels.jsonl"
+    qrels.write_text(json.dumps({"expected_image_ids": ["a.jpg"]}))
+    with pytest.raises(InvalidProfileError) as exc:
+        _load_image_qrels(qrels)
+    assert "query_text" in exc.value.payload["reason"]
+    assert "query_image_path" in exc.value.payload["reason"]
+
+
+def test_loader_rejects_image_row_without_expected_ids(tmp_path: Path):
+    qrels = tmp_path / "qrels.jsonl"
+    qrels.write_text(json.dumps({"query_image_path": "/tmp/q.jpg"}) + "\n")
+    with pytest.raises(InvalidProfileError):
+        _load_image_qrels(qrels)
+
+
+# --- Evaluation ------------------------------------------------------------
+
+
+def test_evaluate_single_image_routes_image_rows_through_image_encoder(
+    tmp_path: Path,
+):
+    query_img = tmp_path / "query.jpg"
+    query_img.write_bytes(b"\xff\xd8\xff\xe0fake")
+    queries = [
+        QueryWithExpectedIds(
+            query=str(query_img),
+            relevant_ids=("/photos/a.jpg",),
+            query_image_path=str(query_img),
+        ),
+    ]
+    fake_client = MagicMock()
+    fake_client.search.return_value = [[_fake_hit("/photos/a.jpg", 0.9)]]
+
+    with (
+        patch("lib.phases.evaluate.MilvusClient", return_value=fake_client),
+        patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]) as mock_encode,
+        patch("lib.phases.evaluate.embed_text_with_clip") as mock_text,
+    ):
+        out = _evaluate_single_image(label="base", plan=IMAGE_PLAN, queries=queries, concurrency=1)
+    # Image row routed through image encoder, not text
+    mock_encode.assert_called()
+    mock_text.assert_not_called()
+    assert out["retrieval"]["recall@10"] == pytest.approx(1.0)
+
+
+def test_evaluate_single_image_caches_image_vectors(tmp_path: Path):
+    query_img = tmp_path / "query.jpg"
+    query_img.write_bytes(b"\xff\xd8")
+    queries = [
+        QueryWithExpectedIds(
+            query=str(query_img),
+            relevant_ids=("/photos/a.jpg",),
+            query_image_path=str(query_img),
+        ),
+        QueryWithExpectedIds(
+            query=str(query_img),
+            relevant_ids=("/photos/a.jpg",),
+            query_image_path=str(query_img),
+        ),
+    ]
+    fake_client = MagicMock()
+    fake_client.search.return_value = [[_fake_hit("/photos/a.jpg", 0.9)]]
+
+    with (
+        patch("lib.phases.evaluate.MilvusClient", return_value=fake_client),
+        patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]) as mock_encode,
+    ):
+        _evaluate_single_image(label="base", plan=IMAGE_PLAN, queries=queries, concurrency=1)
+    # Two identical rows → encoder called once because of the in-run cache
+    assert mock_encode.call_count == 1
+
+
+def test_evaluate_single_image_skips_missing_file_and_continues(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    present = tmp_path / "present.jpg"
+    present.write_bytes(b"\xff\xd8")
+    queries = [
+        QueryWithExpectedIds(
+            query=str(present),
+            relevant_ids=("/photos/a.jpg",),
+            query_image_path=str(present),
+        ),
+        QueryWithExpectedIds(
+            query=str(tmp_path / "missing.jpg"),
+            relevant_ids=("/photos/b.jpg",),
+            query_image_path=str(tmp_path / "missing.jpg"),
+        ),
+    ]
+    fake_client = MagicMock()
+    fake_client.search.return_value = [[_fake_hit("/photos/a.jpg", 0.9)]]
+    with (
+        patch("lib.phases.evaluate.MilvusClient", return_value=fake_client),
+        patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]),
+    ):
+        out = _evaluate_single_image(label="base", plan=IMAGE_PLAN, queries=queries, concurrency=1)
+    # The missing file does not abort the run
+    assert "skipped_queries" in out
+    assert out["skipped_queries"] == [str(tmp_path / "missing.jpg")]
+    # The surviving query still scored
+    assert out["retrieval"]["recall@10"] == pytest.approx(1.0)
+
+
+def test_evaluate_single_image_mixed_rows_route_correctly(tmp_path: Path):
+    query_img = tmp_path / "query.jpg"
+    query_img.write_bytes(b"\xff\xd8")
+    queries = [
+        QueryWithExpectedIds(query="sunset", relevant_ids=("/photos/sun.jpg",)),
+        QueryWithExpectedIds(
+            query=str(query_img),
+            relevant_ids=("/photos/a.jpg",),
+            query_image_path=str(query_img),
+        ),
+    ]
+    fake_client = MagicMock()
+    fake_client.search.side_effect = [
+        [[_fake_hit("/photos/sun.jpg", 0.8)]],
+        [[_fake_hit("/photos/a.jpg", 0.9)]],
+        # Latency pass replays both queries, so the mock needs more returns:
+        [[_fake_hit("/photos/sun.jpg", 0.8)]],
+        [[_fake_hit("/photos/a.jpg", 0.9)]],
+    ]
+    with (
+        patch("lib.phases.evaluate.MilvusClient", return_value=fake_client),
+        patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]) as mock_img,
+        patch(
+            "lib.phases.evaluate.embed_text_with_clip",
+            return_value=[[0.2] * 512],
+        ) as mock_text,
+    ):
+        out = _evaluate_single_image(label="base", plan=IMAGE_PLAN, queries=queries, concurrency=1)
+    # Each branch was exercised at least once
+    assert mock_img.called
+    assert mock_text.called
+    assert out["retrieval"]["recall@10"] == pytest.approx(1.0)

--- a/tests/test_evaluate_query_image.py
+++ b/tests/test_evaluate_query_image.py
@@ -1,0 +1,162 @@
+"""CLI smoke tests for `evaluate --query-image`.
+
+Mocks the Milvus client and CLIP encoder so the test is fast.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+from zilliz_ops import app
+
+
+def _write_plan(out_dir: Path, *, image: bool) -> None:
+    if image:
+        plan = {
+            "collection_name": "img_demo",
+            "target_uri": "http://localhost:19530",
+            "schema": {
+                "primary_key": "image_path",
+                "vector_field": "embedding",
+                "text_field": None,
+                "sparse_field": None,
+                "extra_fields": [],
+                "dim": 512,
+            },
+            "embedding": {
+                "provider": "clip-local",
+                "model": "ViT-B-32",
+                "dim": 512,
+                "modality": "image",
+                "device_hint": "cpu",
+            },
+            "sparse_enabled": False,
+        }
+    else:
+        plan = {
+            "collection_name": "movies",
+            "target_uri": "http://localhost:19530",
+            "schema": {
+                "primary_key": "id",
+                "vector_field": "embedding",
+                "text_field": "body",
+                "sparse_field": "sparse",
+                "extra_fields": [],
+                "dim": 1536,
+            },
+            "embedding": {
+                "provider": "openai",
+                "model": "text-embedding-3-small",
+                "dim": 1536,
+                "modality": "text",
+            },
+            "sparse_enabled": True,
+        }
+    (out_dir / "plan.json").write_text(json.dumps(plan))
+    # preflight_execute_artifact also checks for execute.json
+    (out_dir / "execute.json").write_text(json.dumps({"status": "ok"}))
+
+
+@pytest.fixture
+def image_run(tmp_path: Path) -> Path:
+    _write_plan(tmp_path, image=True)
+    return tmp_path
+
+
+@pytest.fixture
+def text_run(tmp_path: Path) -> Path:
+    _write_plan(tmp_path, image=False)
+    return tmp_path
+
+
+def _fake_hit(pk: str, score: float):
+    hit = MagicMock()
+    hit.id = pk
+    hit.score = score
+    hit.entity = {"image_path": pk}
+    return hit
+
+
+def test_query_image_smoke_prints_top_k_and_exits_zero(image_run: Path, tmp_path_factory):
+    query_img = tmp_path_factory.mktemp("query") / "q.jpg"
+    query_img.write_bytes(b"\xff\xd8\xff\xe0fake")
+
+    fake_client = MagicMock()
+    fake_client.search.return_value = [
+        [
+            _fake_hit("/photos/a.jpg", 0.91),
+            _fake_hit("/photos/b.jpg", 0.85),
+        ]
+    ]
+    runner = CliRunner()
+    with (
+        patch("lib.phases.evaluate.MilvusClient", return_value=fake_client),
+        patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]),
+    ):
+        result = runner.invoke(
+            app,
+            ["evaluate", "--run-dir", str(image_run), "--query-image", str(query_img)],
+        )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # Top-2 ranks rendered with both id and score
+    assert "/photos/a.jpg" in result.stdout
+    assert "/photos/b.jpg" in result.stdout
+    assert "score=0.9100" in result.stdout
+
+
+def test_query_image_and_qrels_are_mutually_exclusive(image_run: Path, tmp_path_factory):
+    query_img = tmp_path_factory.mktemp("query") / "q.jpg"
+    query_img.write_bytes(b"\xff\xd8\xff\xe0")
+    qrels = tmp_path_factory.mktemp("q") / "qrels.jsonl"
+    qrels.write_text('{"query": "x", "relevant_ids": ["1"]}\n')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "evaluate",
+            "--run-dir",
+            str(image_run),
+            "--query-image",
+            str(query_img),
+            "--qrels",
+            str(qrels),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "invalid_profile" in (result.stdout + result.stderr)
+
+
+def test_query_image_on_text_collection_errors(text_run: Path, tmp_path_factory):
+    query_img = tmp_path_factory.mktemp("query") / "q.jpg"
+    query_img.write_bytes(b"\xff\xd8\xff\xe0")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["evaluate", "--run-dir", str(text_run), "--query-image", str(query_img)],
+    )
+    assert result.exit_code != 0
+    combined = result.stdout + result.stderr
+    assert "invalid_profile" in combined
+    assert "image collection" in combined
+
+
+def test_query_image_missing_file_errors(image_run: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "evaluate",
+            "--run-dir",
+            str(image_run),
+            "--query-image",
+            str(image_run / "no-such-file.jpg"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not found" in (result.stdout + result.stderr)

--- a/tests/test_search_image_to_image.py
+++ b/tests/test_search_image_to_image.py
@@ -1,0 +1,130 @@
+"""Unit tests for `search_image_to_image`.
+
+Mocks the Milvus client and both image encoders so the test stays fast and
+doesn't require open-clip-torch weights or a Voyage API key.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from lib.errors import ImageDecodeError, UnsupportedImageProviderError
+from lib.search import search_image_to_image
+
+JPEG_SOI = b"\xff\xd8\xff\xe0"  # arbitrary bytes — encoder is mocked
+
+
+def _image_plan(provider: str = "clip-local", dim: int = 512) -> dict:
+    return {
+        "embedding": {
+            "provider": provider,
+            "model": "ViT-B-32" if provider == "clip-local" else "voyage-multimodal-3",
+            "dim": dim,
+            "modality": "image",
+            "device_hint": "cpu",
+        },
+    }
+
+
+def _fake_milvus_hit(pk: str, score: float):
+    hit = MagicMock()
+    hit.id = pk
+    hit.score = score
+    hit.entity = {"image_path": pk}
+    return hit
+
+
+def test_clip_local_jpeg_routes_through_embed_image_batch():
+    client = MagicMock()
+    client.search.return_value = [[_fake_milvus_hit("/photos/a.jpg", 0.91)]]
+    with patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]) as mock_embed:
+        hits = search_image_to_image(client, "img_demo", JPEG_SOI, _image_plan(), top_k=5)
+    assert len(hits) == 1
+    assert hits[0].id == "/photos/a.jpg"
+    assert hits[0].score == pytest.approx(0.91)
+    mock_embed.assert_called_once()
+    # Confirm the encoder was handed a tempfile path, not raw bytes
+    ((paths,), kwargs) = mock_embed.call_args
+    assert kwargs["model_id"] == "ViT-B-32"
+    assert kwargs["device_hint"] == "cpu"
+    assert len(list(paths)) == 1
+
+
+def test_voyage_multimodal_routes_through_voyage_path():
+    client = MagicMock()
+    client.search.return_value = [[_fake_milvus_hit("/photos/b.png", 0.5)]]
+    plan = _image_plan(provider="voyage", dim=1024)
+    with patch("lib.search.embed_image_batch_voyage", return_value=[[0.2] * 1024]) as mock_voyage:
+        hits = search_image_to_image(client, "img_demo", JPEG_SOI, plan)
+    assert len(hits) == 1
+    assert hits[0].id == "/photos/b.png"
+    mock_voyage.assert_called_once()
+
+
+def test_undecodable_bytes_raise_image_decode_error():
+    client = MagicMock()
+    with (
+        patch(
+            "lib.search.embed_image_batch",
+            side_effect=OSError("cannot identify image file"),
+        ),
+        pytest.raises(ImageDecodeError) as excinfo,
+    ):
+        search_image_to_image(client, "img_demo", b"not an image", _image_plan())
+    payload = excinfo.value.to_dict()
+    assert payload["code"] == "image_decode_failed"
+    assert "cannot identify" in payload["reason"]
+    # Search must not be called when encoding fails
+    client.search.assert_not_called()
+
+
+def test_text_only_provider_raises_typed_error():
+    client = MagicMock()
+    text_plan = {
+        "embedding": {
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dim": 1536,
+            "modality": "text",
+        },
+    }
+    with pytest.raises(UnsupportedImageProviderError) as excinfo:
+        search_image_to_image(client, "img_demo", JPEG_SOI, text_plan)
+    assert excinfo.value.to_dict()["provider"] == "openai"
+    client.search.assert_not_called()
+
+
+def test_empty_encoder_output_raises_image_decode_error():
+    client = MagicMock()
+    with (
+        patch("lib.search.embed_image_batch", return_value=[]),
+        pytest.raises(ImageDecodeError),
+    ):
+        search_image_to_image(client, "img_demo", JPEG_SOI, _image_plan())
+    client.search.assert_not_called()
+
+
+def test_search_respects_top_k_and_output_fields():
+    client = MagicMock()
+    client.search.return_value = [
+        [
+            _fake_milvus_hit("/photos/a.jpg", 0.9),
+            _fake_milvus_hit("/photos/b.jpg", 0.8),
+            _fake_milvus_hit("/photos/c.jpg", 0.7),
+        ]
+    ]
+    with patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]):
+        hits = search_image_to_image(
+            client,
+            "img_demo",
+            JPEG_SOI,
+            _image_plan(),
+            top_k=2,
+            output_fields=["image_path"],
+        )
+    assert len(hits) == 2
+    args, kwargs = client.search.call_args
+    assert kwargs["limit"] == 2
+    assert kwargs["output_fields"] == ["image_path"]
+    assert kwargs["anns_field"] == "embedding"

--- a/tests/test_ui_sidecar_image.py
+++ b/tests/test_ui_sidecar_image.py
@@ -112,6 +112,134 @@ def test_image_search_routes_through_clip_text_encoder(sidecar_app):
     fake_client.search.assert_called_once()
 
 
+def test_embed_image_returns_vector_and_dim(sidecar_app):
+    with patch("lib.ui.embed_image_batch", return_value=[[0.25] * 512]):
+        client = TestClient(sidecar_app)
+        resp = client.post(
+            "/embed_image",
+            files={"file": ("q.jpg", b"\xff\xd8\xff\xe0fake", "image/jpeg")},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["dim"] == 512
+    assert len(data["embedding"]) == 512
+
+
+def test_embed_image_rejects_large_upload(sidecar_app):
+    # 11 MB payload — > 10 MB cap
+    payload = b"x" * (11 * 1024 * 1024)
+    with patch("lib.ui.embed_image_batch", return_value=[[0.0] * 512]):
+        client = TestClient(sidecar_app)
+        resp = client.post("/embed_image", files={"file": ("big.jpg", payload, "image/jpeg")})
+    assert resp.status_code == 413
+    assert resp.json()["detail"]["code"] == "upload_too_large"
+
+
+def test_embed_image_rejects_undecodable_upload(sidecar_app):
+    with patch(
+        "lib.ui.embed_image_batch",
+        side_effect=OSError("cannot identify image file"),
+    ):
+        client = TestClient(sidecar_app)
+        resp = client.post(
+            "/embed_image",
+            files={"file": ("notes.txt", b"not an image", "text/plain")},
+        )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "image_decode_failed"
+
+
+def test_search_image_returns_search_response_shape(sidecar_app):
+    fake_client = MagicMock()
+    hit_a = MagicMock()
+    hit_a.id = "/photos/a.jpg"
+    hit_a.score = 0.91
+    hit_a.entity = {"image_path": "/photos/a.jpg"}
+    fake_client.search.return_value = [[hit_a]]
+    with (
+        patch("lib.ui._client", return_value=fake_client),
+        patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]),
+    ):
+        client = TestClient(sidecar_app)
+        resp = client.post(
+            "/search_image",
+            files={"file": ("q.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")},
+            data={"top_k": "5"},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["modality"] == "image"
+    assert data["mode"] == "dense"
+    assert len(data["hits"]) == 1
+    assert data["hits"][0]["id"] == "/photos/a.jpg"
+    # Thumbnail metadata joined from collect.json fixture
+    assert data["hits"][0]["fields"]["thumbnail_b64"] == "AAA"
+
+
+def test_search_image_clamps_top_k(sidecar_app):
+    fake_client = MagicMock()
+    hit = MagicMock()
+    hit.id = "/photos/a.jpg"
+    hit.score = 0.5
+    hit.entity = {"image_path": "/photos/a.jpg"}
+    fake_client.search.return_value = [[hit]]
+    with (
+        patch("lib.ui._client", return_value=fake_client),
+        patch("lib.search.embed_image_batch", return_value=[[0.1] * 512]),
+    ):
+        client = TestClient(sidecar_app)
+        resp = client.post(
+            "/search_image",
+            files={"file": ("q.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")},
+            data={"top_k": "500"},
+        )
+    assert resp.status_code == 200
+    # Milvus was called with limit clamped to 100, not 500
+    _, kwargs = fake_client.search.call_args
+    assert kwargs["limit"] == 100
+
+
+def test_search_image_on_text_collection_returns_400(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    plan = {
+        "collection_name": "movies",
+        "target_uri": "http://localhost:19530",
+        "schema": {
+            "primary_key": "id",
+            "vector_field": "embedding",
+            "text_field": "body",
+            "sparse_field": "sparse",
+            "extra_fields": [],
+            "dim": 1536,
+        },
+        "embedding": {
+            "provider": "openai",
+            "model": "text-embedding-3-small",
+            "dim": 1536,
+            "modality": "text",
+        },
+        "sparse_enabled": True,
+    }
+    (tmp_path / "plan.json").write_text(json.dumps(plan))
+    monkeypatch.setenv("LAUNCHPAD_RUN_DIR", str(tmp_path))
+    import importlib as _importlib
+
+    import lib.ui as ui_mod
+
+    _importlib.reload(ui_mod)
+    try:
+        client = TestClient(ui_mod.app)
+        resp = client.post(
+            "/search_image",
+            files={"file": ("q.jpg", b"\xff\xd8\xff\xe0", "image/jpeg")},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"]["code"] == "not_image_collection"
+    finally:
+        _importlib.reload(ui_mod)
+
+
 def test_text_run_unchanged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """The existing text path keeps modality=text and no thumbnail join."""
     plan = {

--- a/uv.lock
+++ b/uv.lock
@@ -2208,6 +2208,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3372,6 +3381,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pymilvus" },
+    { name = "python-multipart" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "voyageai" },
@@ -3403,6 +3413,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pymilvus", specifier = ">=2.4" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "torch", marker = "extra == 'multimodal'", specifier = ">=2.2" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },


### PR DESCRIPTION
## Summary

Closes #15. Adds an image-as-query path on top of the image-search collection built by the #14 MVP. No schema or ingest change — the existing CLIP / Voyage-multimodal vectors are reused; only the query-side encoder and the UI input are new.

- **Search library** — `search_image_to_image(client, image_bytes, plan, ...)` in `scripts/lib/search.py`. Routes CLIP-local vs Voyage multimodal from `plan.embedding.provider`, uses a `NamedTemporaryFile(delete=True)` for the bytes → path hand-off, returns the same `Hit` shape as the text-query function. New typed errors `UnsupportedImageProviderError` and `ImageDecodeError` (in `scripts/lib/errors.py`) let the sidecar and CLI turn provider mismatches / undecodable uploads into actionable 400s.
- **Sidecar** — `POST /embed_image` and `POST /search_image` in `scripts/lib/ui.py`. Multipart upload, 10 MB cap (413 beyond), `top_k` clamped to `[1, 100]`, 400 on text-only collections or decode failures. Reuses the CLIP model the sidecar already loads at startup. `python-multipart` added to core deps (FastAPI multipart requirement).
- **Demo UI** — File-picker button + page-wide drag-and-drop drop zone in `scripts/ui/app/page.tsx`; visible only when the active run is an image collection. Client-side MIME guard rejects non-images before POSTing; sidecar 400s render inline without clearing the existing result grid. New `searchSidecarImage(file, topK)` helper in `scripts/ui/lib/milvus-client.ts`.
- **Evaluate** — `evaluate --query-image <path>` smoke flag in `scripts/zilliz_ops.py`; mutually exclusive with `--qrels`, rejects text-only collections via `invalid_profile`, exits zero with a ranked top-k printed to stdout. No metrics report.
- **Qrels** — `_load_image_qrels` now accepts `{query_image_path, expected_image_ids}` rows alongside the existing `{query_text, image_paths}` shape, mixable in one file. `_evaluate_single_image` routes per-row, caches image-query embeddings per-run so the same query file isn't re-encoded across rows, and skips (warn + count) rows whose `query_image_path` points at a missing file.
- **Docs** — README gains a *Search by example (image → image)* subsection (UI + drag-and-drop, CLI smoke, sample qrels row). `SKILL.md` *What this skill does not do* no longer excludes image-to-image; only video frame sampling remains.

## Test plan

Automated (ran locally — 27 new tests, 209/209 total pass, ruff clean):
- [ ] `tests/test_search_image_to_image.py` — CLIP-local JPEG, Voyage-multimodal PNG (mocked), undecodable bytes raise `ImageDecodeError`, text-only provider raises `UnsupportedImageProviderError`, top-k + output-fields are respected (6 tests)
- [ ] `tests/test_ui_sidecar_image.py::test_embed_image_*` + `test_search_image_*` — valid JPEG via `/embed_image`, 413 for >10 MB, 400 for a text file, `/search_image` returns the existing `SearchResponse` shape, `top_k=500` clamps to 100, text-only collection 400s (6 tests)
- [ ] `tests/test_evaluate_query_image.py` — smoke on image collection exits 0 with k ranked lines; `--query-image` + `--qrels` exits non-zero with `invalid_profile`; text-only run exits `invalid_profile`; missing file exits with a clear message (4 tests)
- [ ] `tests/test_evaluate_image_qrels.py` — pure image→image qrels, mixed text+image rows in one file, row missing both keys, row missing expected_ids, per-run embedding cache, missing file is skipped not fatal (8 tests)

Manual (requires live Milvus + a photo library):
- [ ] `tests/manual/image_upload.md` — start sidecar + `pnpm dev`, pick / drop a query image, confirm ranked thumbnail grid; non-image drop → inline error, grid preserved
- [ ] CLI smoke: `evaluate --query-image ./some/photo.jpg --run-dir <image-run>` against a populated image collection prints top-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)