### PR TITLE
feat(launchpad): optional Attu ops UI via compose profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .plans/
+.worktrees/
 
 # Python
 __pycache__/

--- a/skills/zilliz-launchpad/SKILL.md
+++ b/skills/zilliz-launchpad/SKILL.md
@@ -82,6 +82,11 @@ Load only the references you need for the current phase. Do not prefetch all of 
 | 4 Execute    | `cli-reference.md` |
 | 5 Evaluate   | `knowledge/evaluation_guide.md` |
 | 6 Deploy     | `observability/metrics.md`, `observability/query-analysis.md`, `deploy-*.md` (match the target) |
+| Ops (any)    | `ops-attu.md` — when the user wants to inspect, debug, or administer a Milvus cluster beyond what the CLI covers |
+
+## Optional: Attu ops UI
+
+Attu is an opt-in admin UI for developers and ops, not a replacement for the Next.js demo UI. Bring it up with `./start_milvus.sh attu up` (serves on `http://localhost:8000`, bound to loopback) when the user needs to verify ingest, drill into eval bad-cases, or run Cloud operations Attu covers but the CLI does not. See `references/ops-attu.md` for playbooks and Cloud connection instructions.
 
 ## Invoking phases
 

--- a/skills/zilliz-launchpad/references/ops-attu.md
+++ b/skills/zilliz-launchpad/references/ops-attu.md
@@ -1,0 +1,112 @@
+# Attu ops UI — playbooks
+
+Attu is an optional, opt-in Milvus admin UI that ships with launchpad as a
+developer/ops tool. It is **not** a replacement for the Next.js demo UI — the
+demo UI is what you show end users; Attu is what you (or an ops engineer) use to
+look under the hood.
+
+Run it with:
+
+```bash
+cd skills/zilliz-launchpad/scripts
+./start_milvus.sh attu up       # → http://localhost:8000
+./start_milvus.sh attu status
+./start_milvus.sh attu down
+```
+
+The service is declared under compose profile `ops`, so the default
+`./start_milvus.sh up` never pulls or starts it. The web UI is bound to
+`127.0.0.1:8000` only — it is not exposed to your LAN by design (Attu has no
+built-in auth).
+
+To connect Attu to a remote cluster (Zilliz Cloud, a staging Milvus, or a
+BYOC deployment), set env vars before `attu up`:
+
+```bash
+export ATTU_MILVUS_URL=https://<cluster>.api.cloud.zilliz.com
+export ATTU_MILVUS_TOKEN=<cluster-token>
+./start_milvus.sh attu down && ./start_milvus.sh attu up
+```
+
+When either variable is unset, Attu falls back to `standalone:19530` over the
+compose network.
+
+## Playbook 1 — Post-Execute data verification
+
+After Phase 4 (`zilliz_ops.py execute`) completes, use Attu to confirm the data
+actually landed the way plan.json said it would:
+
+1. `./start_milvus.sh attu up` and open `http://localhost:8000`.
+2. In the left sidebar, pick the database, then the collection listed in
+   `execute.json → collection_status`.
+3. **Schema tab** — confirm the primary-key field, vector field name and dim,
+   and every scalar field from `plan.json → schema.fields` are present.
+4. **Data Preview tab** — sample 20 rows. Spot-check:
+   - the primary key is unique and populated
+   - vector fields are non-empty (`[0.0123, …, 512 dims]` — not `null`)
+   - scalar fields match the source JSONL (e.g. titles not truncated, tags not
+     collapsed to `None`)
+5. **Partitions tab** (if plan used partitions) — confirm row counts per
+   partition roughly match expectations; a wildly skewed split usually means
+   the partition key wasn't routed correctly upstream.
+
+If anything is off, re-run `execute` with `--no-ui` on a scratch run-dir rather
+than mutating the current one.
+
+## Playbook 2 — Evaluate bad-case drill-down
+
+When `evaluate.md` flags a recall drop, Attu's Vector Search tab is the
+fastest way to reproduce the query interactively:
+
+1. Open the collection in Attu, go to **Vector Search**.
+2. Paste the offending query vector (pull it from `eval_report.json → queries[i]
+   .vector`) OR type the raw text if your collection has a text-in search
+   function configured.
+3. Set `topK` to the same value used in evaluate (default 10), and set `metric
+   type` and `search params` (nprobe / ef) to the values from `plan.json →
+   index`.
+4. Inspect the top-K result — what actually came back? Common findings:
+   - Expected doc is in top 50 but not top 10 → tune `ef` / `nprobe` upward and
+     re-run evaluate
+   - Expected doc has a stale field (old tag, wrong language) → ingest issue,
+     not a retrieval issue
+   - Expected doc is missing entirely → went missing during ingest
+     (`execute.json → skipped_files`)
+5. Add a filter expression in the same tab (e.g. `lang == "en"`) to reproduce
+   hybrid-filter bad-cases.
+
+Capture the finding as a bullet in the eval report and move on — Attu is the
+drill-down tool, not the scoring tool.
+
+## Playbook 3 — Post-Deploy Cloud ops
+
+After Phase 6 promotes the collection to Zilliz Cloud, point Attu at the
+Cloud endpoint to handle anything the launchpad CLI doesn't:
+
+1. Export `ATTU_MILVUS_URL` and `ATTU_MILVUS_TOKEN` from `deploy.json →
+   public_endpoint` and your `ZILLIZ_TOKEN`, then `./start_milvus.sh attu
+   down && ./start_milvus.sh attu up`.
+2. **Overview tab** — look at load state, segment count, and compaction status.
+   A stuck "Loading" state is usually a quota or replica configuration issue
+   visible here before anywhere else.
+3. **Partitions tab** — check partition load state individually; releasing
+   cold partitions saves memory on Cloud.
+4. **User/Role tab** — create scoped database users instead of handing out the
+   root token. `launchpad` does not automate this today; this is the place to
+   do it.
+5. **System View** — node-level stats; useful when a query-node is hot and you
+   need to size-up before the next eval round.
+
+For SSH-reachable remote hosts, forward the port instead of exposing it:
+
+```bash
+ssh -L 8000:localhost:8000 <jumpbox>
+# then open http://localhost:8000 on your laptop
+```
+
+## Versioning
+
+The Attu image tag is pinned to the Milvus minor version in
+`docker-compose.yml` (`milvusdb/milvus:v2.6.x` ↔ `zilliz/attu:v2.6`). When you
+bump Milvus, bump Attu in the same PR — mismatched majors/minors surface as
+confusing "field not found" errors in the UI before they surface as API errors.

--- a/skills/zilliz-launchpad/scripts/docker-compose.yml
+++ b/skills/zilliz-launchpad/scripts/docker-compose.yml
@@ -65,6 +65,18 @@ services:
       - "etcd"
       - "minio"
 
+  attu:
+    container_name: milvus-attu
+    image: zilliz/attu:v2.6
+    profiles: ["ops"]
+    environment:
+      MILVUS_URL: ${ATTU_MILVUS_URL:-standalone:19530}
+      ATTU_MILVUS_TOKEN: ${ATTU_MILVUS_TOKEN:-}
+    ports:
+      - "127.0.0.1:8000:3000"
+    depends_on:
+      - "standalone"
+
 networks:
   default:
     name: milvus

--- a/skills/zilliz-launchpad/scripts/lib/phases/execute.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/execute.py
@@ -468,6 +468,7 @@ def _run_image_execute(
         "smoke_hits": smoke_hits,
         "ui_port": ui_port if start_ui else None,
         "sidecar_pid": sidecar_pid,
+        "target_uri": plan["target_uri"],
     }
     snap_path.write_text(
         json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8"

--- a/skills/zilliz-launchpad/scripts/start_milvus.sh
+++ b/skills/zilliz-launchpad/scripts/start_milvus.sh
@@ -4,6 +4,11 @@
 #
 # Usage:
 #   ./start_milvus.sh [up|down|status|logs|health|clean]
+#   ./start_milvus.sh attu [up|down|status]
+#
+# The `attu` subcommand brings up the optional Attu ops UI at
+# http://localhost:8000 via the `ops` compose profile. See
+# skills/zilliz-launchpad/references/ops-attu.md for playbooks.
 
 set -euo pipefail
 
@@ -88,8 +93,42 @@ EOF
     rm -rf "${HERE}/volumes"
     echo "Removed containers, compose volumes, and ./volumes/ on disk."
     ;;
+  attu)
+    sub="${2:-up}"
+    case "$sub" in
+      up)
+        _require_docker
+        _check_port 8000
+        docker compose --profile ops up -d attu
+        cat <<EOF
+
+Attu is starting.
+  UI:            http://localhost:8000
+  Default target: standalone:19530 (local Milvus over compose network)
+
+Override to a remote cluster (e.g. Zilliz Cloud) with:
+  export ATTU_MILVUS_URL=https://<cluster>.api.cloud.zilliz.com
+  export ATTU_MILVUS_TOKEN=<token>
+  $0 attu down && $0 attu up
+
+Stop with: $0 attu down
+EOF
+        ;;
+      down)
+        _require_docker
+        docker compose --profile ops rm -sf attu
+        ;;
+      status)
+        docker compose --profile ops ps attu
+        ;;
+      *)
+        echo "Usage: $0 attu [up|down|status]" >&2
+        exit 2
+        ;;
+    esac
+    ;;
   *)
-    echo "Usage: $0 [up|down|status|logs|health|clean]" >&2
+    echo "Usage: $0 [up|down|status|logs|health|clean|attu]" >&2
     exit 2
     ;;
 esac

--- a/skills/zilliz-launchpad/scripts/zilliz_ops.py
+++ b/skills/zilliz-launchpad/scripts/zilliz_ops.py
@@ -180,6 +180,12 @@ def execute(
     if report.get("sidecar_pid"):
         typer.echo(f"UI sidecar pid {report['sidecar_pid']} on port {report['ui_port']}")
         typer.echo("Start the Next.js UI: (cd scripts/ui && pnpm install && pnpm dev)")
+    target_uri = report.get("target_uri", "")
+    if target_uri and "cloud.zilliz.com" not in target_uri:
+        typer.echo(
+            "Tip: run ./start_milvus.sh attu up to inspect the collection in Attu "
+            "(http://localhost:8000)"
+        )
 
 
 @app.command()

--- a/tests/test_attu_compose.py
+++ b/tests/test_attu_compose.py
@@ -1,0 +1,69 @@
+"""Static assertions on the Attu service entry in docker-compose.yml.
+
+These tests only parse YAML — they do not invoke Docker, pull images, or
+start containers, so they are safe to run in any CI environment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+COMPOSE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "zilliz-launchpad"
+    / "scripts"
+    / "docker-compose.yml"
+)
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+
+
+def test_attu_service_exists(compose: dict) -> None:
+    assert "attu" in compose["services"], "attu service missing from docker-compose.yml"
+
+
+def test_attu_image_tag_matches_milvus_minor(compose: dict) -> None:
+    milvus_image = compose["services"]["standalone"]["image"]
+    attu_image = compose["services"]["attu"]["image"]
+    assert milvus_image.startswith("milvusdb/milvus:v2.6"), (
+        "Milvus tag changed; update this test and the Attu tag deliberately"
+    )
+    assert attu_image.startswith("zilliz/attu:v2.6"), (
+        f"Attu tag {attu_image!r} must track Milvus minor (v2.6.x)"
+    )
+
+
+def test_attu_gated_by_ops_profile(compose: dict) -> None:
+    profiles = compose["services"]["attu"].get("profiles")
+    assert profiles == ["ops"], (
+        f"attu must be gated by profile 'ops' so default compose up skips it; got {profiles!r}"
+    )
+
+
+def test_attu_port_bound_to_loopback(compose: dict) -> None:
+    ports = compose["services"]["attu"]["ports"]
+    assert ports == ["127.0.0.1:8000:3000"], (
+        f"attu port must be bound to 127.0.0.1:8000:3000 (loopback only); got {ports!r}"
+    )
+
+
+def test_attu_depends_on_standalone(compose: dict) -> None:
+    deps = compose["services"]["attu"].get("depends_on") or []
+    assert "standalone" in deps, f"attu must depend_on standalone; got {deps!r}"
+
+
+def test_attu_env_vars_support_remote_override(compose: dict) -> None:
+    env = compose["services"]["attu"]["environment"]
+    assert "MILVUS_URL" in env
+    assert "${ATTU_MILVUS_URL:-standalone:19530}" in env["MILVUS_URL"], (
+        "ATTU_MILVUS_URL must override MILVUS_URL with local default"
+    )
+    assert "ATTU_MILVUS_TOKEN" in env

--- a/tests/test_start_milvus_attu.py
+++ b/tests/test_start_milvus_attu.py
@@ -1,0 +1,88 @@
+"""Smoke tests for the `./start_milvus.sh attu ...` subcommand dispatcher.
+
+We stub `docker` (and `lsof`) on PATH so the script never talks to the real
+Docker daemon. This lets us assert exit codes and printed text without
+needing containers running.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "zilliz-launchpad"
+    / "scripts"
+    / "start_milvus.sh"
+)
+
+
+@pytest.fixture()
+def fake_bin(tmp_path: Path) -> Path:
+    """Provide a PATH directory with fake `docker` and `lsof` shims."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    docker = bin_dir / "docker"
+    docker.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "info" ]; then exit 0; fi\n'
+        'if [ "$1" = "compose" ] && [ "$2" = "version" ]; then exit 0; fi\n'
+        'echo "DOCKER-STUB: $*"\n'
+    )
+    docker.chmod(0o755)
+
+    lsof = bin_dir / "lsof"
+    lsof.write_text("#!/usr/bin/env bash\nexit 1\n")  # port always free
+    lsof.chmod(0o755)
+
+    return bin_dir
+
+
+def _run(args: list[str], fake_bin: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:/usr/bin:/bin"
+    return subprocess.run(
+        ["bash", str(SCRIPT_PATH), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_unknown_attu_subcommand_exits_2(fake_bin: Path) -> None:
+    result = _run(["attu", "foo"], fake_bin)
+    assert result.returncode == 2
+    assert "Usage:" in result.stderr
+    assert "attu" in result.stderr
+
+
+def test_attu_no_subcommand_defaults_to_up(fake_bin: Path) -> None:
+    result = _run(["attu"], fake_bin)
+    assert result.returncode == 0, result.stderr
+    assert "DOCKER-STUB: compose --profile ops up -d attu" in result.stdout
+    assert "http://localhost:8000" in result.stdout
+
+
+def test_attu_down_invokes_profile_rm(fake_bin: Path) -> None:
+    result = _run(["attu", "down"], fake_bin)
+    assert result.returncode == 0, result.stderr
+    assert "DOCKER-STUB: compose --profile ops rm -sf attu" in result.stdout
+
+
+def test_attu_status_invokes_profile_ps(fake_bin: Path) -> None:
+    result = _run(["attu", "status"], fake_bin)
+    assert result.returncode == 0, result.stderr
+    assert "DOCKER-STUB: compose --profile ops ps attu" in result.stdout
+
+
+def test_top_level_usage_mentions_attu(fake_bin: Path) -> None:
+    result = _run(["bogus"], fake_bin)
+    assert result.returncode == 2
+    assert "attu" in result.stderr


### PR DESCRIPTION
Closes #2.

## Summary
- Add `zilliz/attu:v2.6` as a **compose service gated by profile `ops`** in `skills/zilliz-launchpad/scripts/docker-compose.yml`. Default `./start_milvus.sh up` is unchanged and does not pull the Attu image.
- New `./start_milvus.sh attu up|down|status` subcommand wraps `docker compose --profile ops`. UI served on `http://localhost:8000`, bound to loopback only (Attu has no built-in auth).
- Defaults to local Milvus via compose DNS (`standalone:19530`); override to Zilliz Cloud or any remote cluster by exporting `ATTU_MILVUS_URL` / `ATTU_MILVUS_TOKEN` before `attu up`.
- Execute phase (`zilliz_ops.py execute`) prints a one-line tip to bring up Attu only when the target is local.
- New `skills/zilliz-launchpad/references/ops-attu.md` with three playbooks:
  1. Post-Execute data verification (schema/row spot-check)
  2. Evaluate bad-case drill-down (Attu Vector Search tab)
  3. Post-Deploy Cloud ops (load state, partitions, user/role)
- `SKILL.md` points to the new ops reference and positions Attu as a developer/ops tool (not a demo-UI replacement).

## Why this shape, not the Electron client
Launchpad already requires Docker for local Milvus. Reusing that dependency keeps the experience a single command on Mac/Windows/Linux, avoids per-OS installers, and lets us pin the Attu tag next to `milvusdb/milvus` in the same compose file so version drift surfaces in PR review. See `openspec/changes/add-attu-ops-ui/design.md` (local planning artifact, not committed) for full tradeoffs.

## Test plan
- [x] `uv run pytest` — **193 passed / 3 skipped / 3 failed**. The 3 failures are the pre-existing `test_execute_image.py` multimodal-dep failures unrelated to this change (master has the same baseline).
- [x] `uv run ruff check` — clean on all modified files.
- [x] `docker compose config --services` — default lists only `etcd minio standalone`; `docker compose --profile ops config --services` adds `attu`.
- [x] `./start_milvus.sh attu foo` exits `2` and prints usage; `./start_milvus.sh attu` / `attu down` / `attu status` invoke the right `docker compose --profile ops …` commands (covered by new `tests/test_start_milvus_attu.py`).
- [ ] **Manual e2e (to run before merge on a machine with Docker):** `./start_milvus.sh up && ./start_milvus.sh attu up`, open http://localhost:8000, confirm a launchpad-created collection appears in Attu and its schema matches `plan.json`.
- [ ] **Manual Cloud e2e (optional):** `export ATTU_MILVUS_URL=… ATTU_MILVUS_TOKEN=…`, `./start_milvus.sh attu down && ./start_milvus.sh attu up`, confirm Cloud collections are visible.

## Out of scope
- No Attu auth/multi-tenant changes — relying on loopback binding.
- No Electron client packaging.
- Existing six-phase CLI contract is unchanged; the tip in Execute output is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)