### PR TITLE
feat(launchpad): Phase 1 Collect — PDF and Markdown inputs (#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             exit 1
           fi
       - name: Unit tests
-        run: uv run pytest -m "not cloud and not e2e and not multimodal"
+        run: uv run pytest -m "not cloud and not e2e and not multimodal and not documents"
 
   multimodal:
     runs-on: ubuntu-latest
@@ -66,6 +66,17 @@ jobs:
       - run: uv sync --extra multimodal --dev
       - name: Multimodal tests
         run: uv run pytest -m "multimodal and not cloud and not e2e"
+
+  documents:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.11"
+      - run: uv sync --extra documents --dev
+      - name: Documents tests
+        run: uv run pytest -m "documents and not cloud and not e2e"
 
   ui:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Looks at your file, infers field types, picks a candidate primary key and text f
 ```bash
 uv run python skills/zilliz-launchpad/scripts/zilliz_ops.py collect --sample movies
 # or: --input path/to/your.jsonl
+# or: --input path/to/your.pdf      # one record per page (requires `.[documents]` extra)
+# or: --input path/to/notes.md      # whole file; add --split-markdown-headings for `## ` sections
 ```
 
 Output (`collect.json`, abbreviated):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,4 +67,5 @@ markers = [
     "cloud: requires Zilliz Cloud credentials (excluded from default CI)",
     "e2e: requires running Milvus Standalone",
     "multimodal: requires the [multimodal] extra (torch + open-clip-torch)",
+    "documents: requires the [documents] extra (pypdf)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ multimodal = [
     "open-clip-torch>=2.24",
     "torch>=2.2",
 ]
+documents = [
+    "pypdf>=4",
+]
 
 [dependency-groups]
 dev = [
@@ -52,7 +55,7 @@ exclude = ["skills/zilliz-launchpad/scripts/ui", "skills/zilliz-launchpad/script
 [[tool.mypy.overrides]]
 module = [
     "pymilvus.*", "voyageai.*", "cohere.*", "open_clip.*", "torch.*", "PIL.*",
-    "anthropic.*",
+    "anthropic.*", "pypdf.*",
 ]
 ignore_missing_imports = true
 

--- a/skills/zilliz-launchpad/SKILL.md
+++ b/skills/zilliz-launchpad/SKILL.md
@@ -93,7 +93,7 @@ Attu is an opt-in admin UI for developers and ops, not a replacement for the Nex
 Assume the working directory is the repo root.
 
 ```bash
-# Phase 1 — sample data (or --input your.jsonl)
+# Phase 1 — sample data (or --input your.jsonl / .csv / .txt / .md / .pdf / image dir)
 uv run python skills/zilliz-launchpad/scripts/zilliz_ops.py collect --sample movies
 
 # Phase 2 — take defaults with overrides

--- a/skills/zilliz-launchpad/references/knowledge/document_processing.md
+++ b/skills/zilliz-launchpad/references/knowledge/document_processing.md
@@ -1,5 +1,20 @@
 # Document processing / chunking
 
+## Supported input shapes
+
+Phase 1 Collect accepts the following file shapes. Downstream chunking is unchanged — the recursive splitter still runs over whatever `text` field Collect emits.
+
+| Suffix | `data_shape` | Records emitted | Notes |
+|--------|--------------|-----------------|-------|
+| `.jsonl` / `.ndjson` | `jsonl` | one per line | inferred fields |
+| `.csv` | `csv` | one per row | inferred fields |
+| `.txt` | `text` | one per file | whole file as `text` |
+| `.md` | `markdown` | one per file (default), or one per `## ` section with `--split-markdown-headings` | a leading `---\n…\n---\n` YAML front-matter block is stripped |
+| `.pdf` | `pdf` | one per page (1-indexed `page_number`, plus `source_path`) | requires `pip install zilliz-launchpad[documents]`; surfaces a warning when no extractable text is found (likely a scanned PDF — add an OCR step yourself) |
+| directory of images | `image_dir` | one per image | see `image_embedding_models.md` |
+
+`--split-markdown-headings` is opt-in because most onboarding docs are short enough that one-record-per-file is the right default. Turn it on for longer hand-written notes structured around `##` sections.
+
 ## Default strategy
 
 Recursive character splitter targeting **~512 approximate tokens** with **~64 token overlap**. Separators (in order): paragraph (`\n\n`), line (`\n`), sentence (`. `), word (` `), character (hard cut).

--- a/skills/zilliz-launchpad/scripts/lib/phases/collect.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/collect.py
@@ -12,7 +12,7 @@ from typing import Any
 from PIL import UnidentifiedImageError
 
 from .. import samples
-from ..errors import InvalidProfileError
+from ..errors import InvalidProfileError, MissingDependencyError
 from ..image_io import (
     IMAGE_SUFFIXES,
     THUMBNAIL_DEFAULT_CAP_ROWS,
@@ -20,8 +20,10 @@ from ..image_io import (
     read_image_metadata,
 )
 
-SUPPORTED_SUFFIXES = {".jsonl", ".ndjson", ".csv", ".txt"}
+SUPPORTED_SUFFIXES = {".jsonl", ".ndjson", ".csv", ".txt", ".md", ".pdf"}
 SUPPORTED_DIR_SUFFIXES = IMAGE_SUFFIXES
+
+PDF_SCANNED_TEXT_THRESHOLD = 50
 
 
 def _infer_field_type(values: list[Any]) -> str:
@@ -158,6 +160,162 @@ def _read_image_dir(
     }
 
 
+def _strip_yaml_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return text
+    return text[end + len("\n---\n") :]
+
+
+def _split_markdown_sections(text: str) -> list[tuple[str, str]]:
+    sections: list[tuple[str, str]] = []
+    current_heading: str | None = None
+    current_lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if current_heading is not None:
+                body = "\n".join(current_lines).strip()
+                if body:
+                    sections.append((current_heading, body))
+            current_heading = line[3:].strip()
+            current_lines = []
+        elif current_heading is not None:
+            current_lines.append(line)
+    if current_heading is not None:
+        body = "\n".join(current_lines).strip()
+        if body:
+            sections.append((current_heading, body))
+    return sections
+
+
+def _read_markdown(path: Path, *, split_headings: bool) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    text = _strip_yaml_frontmatter(raw)
+    stem = path.stem
+
+    sections = _split_markdown_sections(text) if split_headings else []
+
+    if sections:
+        records: list[dict[str, Any]] = [
+            {"id": f"{stem}-s{i}", "text": body, "section_heading": heading}
+            for i, (heading, body) in enumerate(sections, start=1)
+        ]
+        text_lens = [len(r["text"]) for r in records]
+        head_lens = [len(r["section_heading"]) for r in records]
+        fields: list[dict[str, Any]] = [
+            {
+                "name": "id",
+                "type": "string",
+                "avg_length": int(sum(len(r["id"]) for r in records) / len(records)),
+                "sample_value": records[0]["id"],
+            },
+            {
+                "name": "text",
+                "type": "string",
+                "avg_length": int(sum(text_lens) / len(text_lens)),
+                "sample_value": records[0]["text"][:200],
+            },
+            {
+                "name": "section_heading",
+                "type": "string",
+                "avg_length": int(sum(head_lens) / len(head_lens)),
+                "sample_value": records[0]["section_heading"],
+            },
+        ]
+    else:
+        body = text.strip()
+        records = [{"id": f"{stem}-1", "text": body}]
+        fields = [
+            {
+                "name": "id",
+                "type": "string",
+                "avg_length": len(records[0]["id"]),
+                "sample_value": records[0]["id"],
+            },
+            {
+                "name": "text",
+                "type": "string",
+                "avg_length": len(body),
+                "sample_value": body[:200],
+            },
+        ]
+
+    return {
+        "data_shape": "markdown",
+        "fields": fields,
+        "suggested_primary_key": "id",
+        "suggested_text_field": "text",
+        "record_count_estimate": len(records),
+    }
+
+
+def _read_pdf(path: Path) -> dict[str, Any]:
+    try:
+        from pypdf import PdfReader
+    except ImportError as exc:
+        raise MissingDependencyError(
+            feature="pdf-collect",
+            install_hint="pip install zilliz-launchpad[documents]",
+        ) from exc
+
+    reader = PdfReader(str(path))
+    stem = path.stem
+    records: list[dict[str, Any]] = []
+    for i, page in enumerate(reader.pages, start=1):
+        page_text = page.extract_text() or ""
+        records.append(
+            {
+                "id": f"{stem}-p{i}",
+                "text": page_text,
+                "page_number": i,
+                "source_path": str(path),
+            }
+        )
+
+    text_lens = [len(r["text"]) for r in records]
+    fields: list[dict[str, Any]] = [
+        {
+            "name": "id",
+            "type": "string",
+            "avg_length": int(sum(len(r["id"]) for r in records) / max(len(records), 1)),
+            "sample_value": records[0]["id"] if records else None,
+        },
+        {
+            "name": "text",
+            "type": "string",
+            "avg_length": int(sum(text_lens) / len(text_lens)) if text_lens else 0,
+            "sample_value": records[0]["text"][:200] if records else None,
+        },
+        {
+            "name": "page_number",
+            "type": "int",
+            "sample_value": records[0]["page_number"] if records else None,
+        },
+        {
+            "name": "source_path",
+            "type": "string",
+            "avg_length": len(str(path)),
+            "sample_value": str(path),
+        },
+    ]
+
+    result: dict[str, Any] = {
+        "data_shape": "pdf",
+        "fields": fields,
+        "suggested_primary_key": "id",
+        "suggested_text_field": "text",
+        "record_count_estimate": len(records),
+    }
+    if sum(text_lens) < PDF_SCANNED_TEXT_THRESHOLD:
+        result["warnings"] = [
+            f"PDF '{path.name}' appears to contain no extractable text — likely a "
+            "scanned image; consider an OCR pre-processing step."
+        ]
+    return result
+
+
 def run_collect(
     *,
     input_path: str | None,
@@ -165,6 +323,7 @@ def run_collect(
     out_dir: Path,
     with_thumbnails: bool | None = None,
     thumbnail_cap_rows: int = THUMBNAIL_DEFAULT_CAP_ROWS,
+    split_markdown_headings: bool = False,
 ) -> dict[str, Any]:
     if sample is not None:
         records = list(samples.load(sample))
@@ -208,9 +367,14 @@ def run_collect(
                     "suggested_text_field": "text",
                     "record_count_estimate": 1,
                 }
+            elif suffix == ".md":
+                result = _read_markdown(path, split_headings=split_markdown_headings)
+            elif suffix == ".pdf":
+                result = _read_pdf(path)
             else:
                 raise ValueError(
-                    f"Unsupported input suffix: {suffix}. Use {SUPPORTED_SUFFIXES} "
+                    f"Unsupported input suffix: {suffix}. "
+                    f"Use {sorted(SUPPORTED_SUFFIXES)} "
                     f"or pass a directory of images ({sorted(IMAGE_SUFFIXES)})"
                 )
             result["source_path"] = str(path)

--- a/skills/zilliz-launchpad/scripts/zilliz_ops.py
+++ b/skills/zilliz-launchpad/scripts/zilliz_ops.py
@@ -57,6 +57,11 @@ def collect(
         "--thumbnail-cap-rows",
         help="Image dir only. Auto-disable thumbnails above this many images.",
     ),
+    split_markdown_headings: bool = typer.Option(
+        False,
+        "--split-markdown-headings/--no-split-markdown-headings",
+        help="Markdown only. Emit one record per `## ` section instead of one per file.",
+    ),
 ) -> None:
     """Phase 1 — analyze sample data."""
     if sample is None and input is None:
@@ -73,14 +78,23 @@ def collect(
             out_dir=out,
             with_thumbnails=with_thumbnails,
             thumbnail_cap_rows=thumbnail_cap_rows,
+            split_markdown_headings=split_markdown_headings,
         )
     except LaunchpadError as e:
         _fail(e)
     typer.echo(f"run-dir: {out}")
-    if result.get("data_shape") == "image_dir":
+    shape = result.get("data_shape")
+    if shape == "image_dir":
         typer.echo("data_shape: image_dir")
         typer.echo(f"images: {result['record_count_estimate']}")
         typer.echo(f"thumbnails_included: {result['thumbnails_included']}")
+    elif shape in ("markdown", "pdf"):
+        typer.echo(f"data_shape: {shape}")
+        typer.echo(f"records: {result['record_count_estimate']}")
+        typer.echo(f"suggested_primary_key: {result['suggested_primary_key']}")
+        typer.echo(f"suggested_text_field: {result['suggested_text_field']}")
+        for warning in result.get("warnings", []):
+            typer.echo(f"warning: {warning}", err=True)
     else:
         typer.echo(f"suggested_primary_key: {result['suggested_primary_key']}")
         typer.echo(f"suggested_text_field: {result['suggested_text_field']}")

--- a/tests/fixtures/documents/sample.md
+++ b/tests/fixtures/documents/sample.md
@@ -1,0 +1,28 @@
+---
+title: Sample document
+author: zilliz-launchpad
+tags: [test, fixture]
+---
+
+# Sample document
+
+A short prose preamble before the first `##` heading. The heading-split
+reader discards this preamble; the whole-file reader keeps it.
+
+## Introduction
+
+Vector search starts with a sample document. This fixture exercises the
+Phase 1 Collect Markdown reader, including front-matter stripping and
+the optional `## ` heading split.
+
+## Approach
+
+The default Markdown reader treats the entire file as one record so a
+README-style document round-trips with no surprises. The
+`--split-markdown-headings` flag emits one record per top-level heading,
+which is useful for longer hand-written notes.
+
+## Notes
+
+Chunking still happens later, in Phase 4 — this reader only decides the
+record boundary, not the embedding-token boundary.

--- a/tests/fixtures/documents/sample.pdf
+++ b/tests/fixtures/documents/sample.pdf
@@ -1,0 +1,112 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260424115349+08'00') /Creator (anonymous) /Keywords () /ModDate (D:20260424115349+08'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 3 /Kids [ 4 0 R 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 174
+>>
+stream
+GarWq0aki`%#3`S^Z$3_iG=NPkpkmBkRcO11KpX,b$Ds#D`L6J84&&TGX<h!TmV7ger8^V5Se_O<MfidYi-dM$`\8dN;[nq&1]h[#nE=CgdSI9AIcG*(LQ)b49=a0%33@Q&<Xn"h]f%XRddt)$]!f[]b?n?rs7&RR63e*!qi?F*r~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 177
+>>
+stream
+GarWq0b2&S$jG"kVt_KJ#^')]FeuGY6O$m?"@Ik]Jm+sVT+DQU5die&>L.sH(8^7XY[_K1!bq-A<2pRY5g*<Q25j,mXn49E&$aZi$a@[ofSb:COFsapob[B607^'O"0H]/beD!n,osr.0,)2s@!Xn+4Dr"iLjNNg]CD[4T9)2:`Eb9+~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 170
+>>
+stream
+GarWqYmu@N%*%h.Vt``'39Z'(=A<mHE9I[kZNs#qF*-@14\qg]VG2jGn112k6g;/gfJAC0JLn;9<Mfi,3,k1p"kBS2`r8#ILn0N0Jg]WWmNUR4Lhsk.nFfNQVcQ:B]EoV^.Z:#Cj`ZCE65X9g`r()Gmd=)fc=Z_Mfb;YH15l~>endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000515 00000 n 
+0000000709 00000 n 
+0000000903 00000 n 
+0000000971 00000 n 
+0000001232 00000 n 
+0000001303 00000 n 
+0000001568 00000 n 
+0000001836 00000 n 
+trailer
+<<
+/ID 
+[<01271764cfc42412f9ac2938896fc263><01271764cfc42412f9ac2938896fc263>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
+>>
+startxref
+2097
+%%EOF

--- a/tests/fixtures/documents/scanned.pdf
+++ b/tests/fixtures/documents/scanned.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260424115349+08'00') /Creator (anonymous) /Keywords () /ModDate (D:20260424115349+08'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 59
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_PP$O!3^,C5Q~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000061 00000 n 
+0000000092 00000 n 
+0000000199 00000 n 
+0000000392 00000 n 
+0000000460 00000 n 
+0000000721 00000 n 
+0000000780 00000 n 
+trailer
+<<
+/ID 
+[<716306810f6af8beb75859ea14cd5a80><716306810f6af8beb75859ea14cd5a80>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+928
+%%EOF

--- a/tests/test_collect_markdown.py
+++ b/tests/test_collect_markdown.py
@@ -1,0 +1,78 @@
+"""Phase 1 Collect — Markdown branch."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from lib.phases.collect import (
+    SUPPORTED_SUFFIXES,
+    _strip_yaml_frontmatter,
+    run_collect,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "documents" / "sample.md"
+
+
+def test_markdown_default_emits_one_record(tmp_path: Path):
+    result = run_collect(input_path=str(FIXTURE), sample=None, out_dir=tmp_path)
+
+    assert result["data_shape"] == "markdown"
+    assert result["record_count_estimate"] == 1
+    assert result["suggested_primary_key"] == "id"
+    assert result["suggested_text_field"] == "text"
+
+    field_names = {f["name"] for f in result["fields"]}
+    assert field_names == {"id", "text"}
+
+    text_field = next(f for f in result["fields"] if f["name"] == "text")
+    assert text_field["sample_value"].startswith("# Sample document")
+
+
+def test_markdown_split_headings_emits_one_record_per_section(tmp_path: Path):
+    result = run_collect(
+        input_path=str(FIXTURE),
+        sample=None,
+        out_dir=tmp_path,
+        split_markdown_headings=True,
+    )
+
+    assert result["data_shape"] == "markdown"
+    assert result["record_count_estimate"] == 3
+
+    field_names = {f["name"] for f in result["fields"]}
+    assert {"text", "section_heading"} <= field_names
+
+    written = json.loads((tmp_path / "collect.json").read_text())
+    assert written["data_shape"] == "markdown"
+    assert written["record_count_estimate"] == 3
+
+
+def test_yaml_frontmatter_is_stripped(tmp_path: Path):
+    result = run_collect(input_path=str(FIXTURE), sample=None, out_dir=tmp_path)
+    sample = next(f for f in result["fields"] if f["name"] == "text")["sample_value"]
+    assert "title: Sample document" not in sample
+    assert "---" not in sample.split("\n")[0]
+
+
+def test_strip_yaml_frontmatter_unit():
+    raw = "---\nkey: value\nother: 1\n---\nbody line\n"
+    assert _strip_yaml_frontmatter(raw) == "body line\n"
+    # No front-matter → unchanged
+    assert _strip_yaml_frontmatter("body only\n") == "body only\n"
+    # Unterminated front-matter → unchanged
+    assert _strip_yaml_frontmatter("---\nkey: value\n") == "---\nkey: value\n"
+
+
+def test_md_in_supported_suffixes():
+    assert ".md" in SUPPORTED_SUFFIXES
+
+
+def test_unsupported_suffix_message_lists_md_and_pdf(tmp_path: Path):
+    bogus = tmp_path / "data.xyz"
+    bogus.write_text("nothing")
+    with pytest.raises(ValueError) as exc:
+        run_collect(input_path=str(bogus), sample=None, out_dir=tmp_path)
+    assert ".md" in str(exc.value)
+    assert ".pdf" in str(exc.value)

--- a/tests/test_collect_pdf.py
+++ b/tests/test_collect_pdf.py
@@ -14,6 +14,7 @@ SAMPLE_PDF = FIXTURES / "sample.pdf"
 SCANNED_PDF = FIXTURES / "scanned.pdf"
 
 
+@pytest.mark.documents
 def test_pdf_happy_path_emits_one_record_per_page(tmp_path: Path):
     result = run_collect(input_path=str(SAMPLE_PDF), sample=None, out_dir=tmp_path)
 
@@ -32,6 +33,7 @@ def test_pdf_happy_path_emits_one_record_per_page(tmp_path: Path):
     assert "warnings" not in result
 
 
+@pytest.mark.documents
 def test_pdf_with_no_extractable_text_emits_warning(tmp_path: Path):
     result = run_collect(input_path=str(SCANNED_PDF), sample=None, out_dir=tmp_path)
 

--- a/tests/test_collect_pdf.py
+++ b/tests/test_collect_pdf.py
@@ -1,0 +1,59 @@
+"""Phase 1 Collect — PDF branch."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from lib.errors import MissingDependencyError
+from lib.phases.collect import SUPPORTED_SUFFIXES, run_collect
+
+FIXTURES = Path(__file__).parent / "fixtures" / "documents"
+SAMPLE_PDF = FIXTURES / "sample.pdf"
+SCANNED_PDF = FIXTURES / "scanned.pdf"
+
+
+def test_pdf_happy_path_emits_one_record_per_page(tmp_path: Path):
+    result = run_collect(input_path=str(SAMPLE_PDF), sample=None, out_dir=tmp_path)
+
+    assert result["data_shape"] == "pdf"
+    assert result["record_count_estimate"] == 3
+    assert result["suggested_primary_key"] == "id"
+    assert result["suggested_text_field"] == "text"
+
+    field_names = {f["name"] for f in result["fields"]}
+    assert {"id", "text", "page_number", "source_path"} <= field_names
+
+    page_number_field = next(f for f in result["fields"] if f["name"] == "page_number")
+    assert page_number_field["type"] == "int"
+    assert page_number_field["sample_value"] == 1
+
+    assert "warnings" not in result
+
+
+def test_pdf_with_no_extractable_text_emits_warning(tmp_path: Path):
+    result = run_collect(input_path=str(SCANNED_PDF), sample=None, out_dir=tmp_path)
+
+    assert result["data_shape"] == "pdf"
+    assert "warnings" in result
+    assert any("scanned" in w.lower() for w in result["warnings"])
+
+
+def test_pdf_in_supported_suffixes():
+    assert ".pdf" in SUPPORTED_SUFFIXES
+
+
+def test_missing_pypdf_raises_missing_dependency_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Force the lazy `from pypdf import PdfReader` inside _read_pdf to fail.
+    monkeypatch.setitem(sys.modules, "pypdf", None)
+
+    with pytest.raises(MissingDependencyError) as exc:
+        run_collect(input_path=str(SAMPLE_PDF), sample=None, out_dir=tmp_path)
+
+    assert exc.value.payload["feature"] == "pdf-collect"
+    assert exc.value.payload["install_hint"] == "pip install zilliz-launchpad[documents]"
+    envelope = exc.value.to_dict()
+    assert envelope["code"] == "missing_dependency"

--- a/uv.lock
+++ b/uv.lock
@@ -2146,6 +2146,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3388,6 +3397,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+documents = [
+    { name = "pypdf" },
+]
 multimodal = [
     { name = "open-clip-torch" },
     { name = "torch" },
@@ -3413,13 +3425,14 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pymilvus", specifier = ">=2.4" },
+    { name = "pypdf", marker = "extra == 'documents'", specifier = ">=4" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "torch", marker = "extra == 'multimodal'", specifier = ">=2.2" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
     { name = "voyageai", specifier = ">=0.2" },
 ]
-provides-extras = ["multimodal"]
+provides-extras = ["multimodal", "documents"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Phase 1 Collect now accepts `.md` (one record per file, optional `--split-markdown-headings` for `## ` sections, YAML front-matter stripped) and `.pdf` (one record per page, 1-indexed `page_number` + `source_path`).
- PDF support is opt-in via a new `[documents]` extra (`pypdf>=4`); a missing `pypdf` surfaces a structured `MissingDependencyError` with `install_hint`, not a raw `ImportError`. PDFs with under 50 chars of extractable text get a "likely scanned" warning so users can decide to add OCR themselves.
- Closes #4.

## Test plan
- [x] `pytest -q` — 230 passed, 3 skipped
- [x] `ruff check` on changed files — clean
- [x] `mypy` on `collect.py` — clean
- [x] Smoke: `zilliz_ops.py collect --input tests/fixtures/documents/sample.pdf` → `data_shape=pdf, records=3`
- [x] Missing-pypdf path produces `{"code":"missing_dependency","feature":"pdf-collect","install_hint":"pip install zilliz-launchpad[documents]"}`
- [ ] Reviewer: spot-check the `.md` walkthrough one-liner in `README.md` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)