### PR TITLE
fix(launchpad): add fields via add_collection_field instead of dropping collection

### DIFF
--- a/skills/zilliz-launchpad/scripts/lib/operations.py
+++ b/skills/zilliz-launchpad/scripts/lib/operations.py
@@ -50,55 +50,113 @@ def _schema_fingerprint(schema: CollectionSchema) -> list[tuple[str, str, dict[s
     return sorted(out, key=lambda r: r[0])
 
 
-def _diff_schemas(
+def _classify_diff(
     existing_fields: list[dict[str, Any]],
     requested: CollectionSchema,
-) -> list[str]:
-    """Return human-readable mismatch strings; empty list if compatible."""
-    wanted = {
-        f.name: (_dtype_name(f.dtype), dict(getattr(f, "params", {}) or {}))
-        for f in requested.fields
-    }
+) -> tuple[list[FieldSchema], list[str]]:
+    """Split a schema diff into (additive, fatal).
+
+    `additive` is the list of FieldSchema entries present in the plan but not
+    in the existing collection — candidates for `add_collection_field`.
+    `fatal` is a list of human-readable strings describing incompatible
+    differences (type/param mismatch, or fields present in the existing
+    collection but dropped from the plan).
+    """
     have = {
         f["name"]: (_dtype_name(f.get("type")), dict(f.get("params") or {}))
         for f in existing_fields
     }
+    wanted_names = {f.name for f in requested.fields}
 
-    mismatches: list[str] = []
-    for name, (wtype, wparams) in wanted.items():
-        if name not in have:
-            mismatches.append(f"missing field: {name}")
+    additive: list[FieldSchema] = []
+    fatal: list[str] = []
+
+    for f in requested.fields:
+        wtype = _dtype_name(f.dtype)
+        wparams = dict(getattr(f, "params", {}) or {})
+        if f.name not in have:
+            additive.append(f)
             continue
-        htype, hparams = have[name]
+        htype, hparams = have[f.name]
         if wtype != htype:
-            mismatches.append(f"field '{name}' type differs: have {htype}, want {wtype}")
+            fatal.append(f"field '{f.name}' type differs: have {htype}, want {wtype}")
         for key in ("dim", "max_length"):
             if key in wparams and wparams[key] != hparams.get(key):
-                mismatches.append(
-                    f"field '{name}' param '{key}' differs: "
+                fatal.append(
+                    f"field '{f.name}' param '{key}' differs: "
                     f"have {hparams.get(key)}, want {wparams[key]}"
                 )
+
     for name in have:
-        if name not in wanted:
-            mismatches.append(f"extra field (not in plan): {name}")
-    return mismatches
+        if name not in wanted_names:
+            fatal.append(f"extra field (not in plan): {name}")
+
+    return additive, fatal
+
+
+def _diff_schemas(
+    existing_fields: list[dict[str, Any]],
+    requested: CollectionSchema,
+) -> list[str]:
+    """Return human-readable mismatch strings; empty list if compatible.
+
+    Preserved as a thin wrapper over `_classify_diff` so callers that just
+    want a flat list (tests, error payloads) keep working.
+    """
+    additive, fatal = _classify_diff(existing_fields, requested)
+    return [f"missing field: {f.name}" for f in additive] + fatal
+
+
+def _add_field_kwargs(field: FieldSchema) -> dict[str, Any]:
+    """Build kwargs for `MilvusClient.add_collection_field` from a FieldSchema.
+
+    Fields added to a live collection must be nullable — Milvus fills existing
+    rows with null / default so the operation stays online.
+    """
+    params = dict(getattr(field, "params", {}) or {})
+    kwargs: dict[str, Any] = {"nullable": True}
+    # Forward only the field-schema kwargs that `create_field_schema` accepts.
+    for key in ("max_length", "dim", "element_type", "max_capacity"):
+        if key in params:
+            kwargs[key] = params[key]
+    return kwargs
 
 
 def create_collection(
     client: MilvusClient,
     name: str,
     schema: CollectionSchema,
-) -> Literal["created", "reused"]:
-    """Idempotent create. Raises `SchemaConflictError` on mismatch."""
-    if collection_exists(client, name):
-        info = client.describe_collection(name)
-        existing_fields = info.get("fields", [])
-        mismatches = _diff_schemas(existing_fields, schema)
-        if mismatches:
-            raise SchemaConflictError(collection=name, mismatches=mismatches)
+) -> Literal["created", "reused", "extended"]:
+    """Idempotent create with additive schema evolution.
+
+    - If the collection is absent: create it.
+    - If present and schema matches: reuse.
+    - If present and the only differences are fields the plan added that the
+      collection lacks (type/param of shared fields still match): call
+      `add_collection_field` for each and return `"extended"`. The new fields
+      are added as nullable so existing rows remain valid.
+    - Otherwise: raise `SchemaConflictError`.
+    """
+    if not collection_exists(client, name):
+        client.create_collection(collection_name=name, schema=schema)
+        return "created"
+
+    info = client.describe_collection(name)
+    existing_fields = info.get("fields", [])
+    additive, fatal = _classify_diff(existing_fields, schema)
+    if fatal:
+        mismatches = [f"missing field: {f.name}" for f in additive] + fatal
+        raise SchemaConflictError(collection=name, mismatches=mismatches)
+    if not additive:
         return "reused"
-    client.create_collection(collection_name=name, schema=schema)
-    return "created"
+    for field in additive:
+        client.add_collection_field(
+            collection_name=name,
+            field_name=field.name,
+            data_type=field.dtype,
+            **_add_field_kwargs(field),
+        )
+    return "extended"
 
 
 def load_collection(client: MilvusClient, name: str) -> None:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -77,3 +77,72 @@ def test_create_collection_reuses_on_match(mocker):
     status = create_collection(client, "docs", _schema(dim=4))
     assert status == "reused"
     client.create_collection.assert_not_called()
+
+
+def _schema_with_tags(dim: int = 4) -> CollectionSchema:
+    return CollectionSchema(
+        fields=[
+            FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True, max_length=128),
+            FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65535),
+            FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim=dim),
+            FieldSchema(name="tags", dtype=DataType.VARCHAR, max_length=512),
+        ]
+    )
+
+
+def test_create_collection_extends_on_missing_field(mocker):
+    client = mocker.Mock()
+    client.list_collections.return_value = ["docs"]
+    client.describe_collection.return_value = {
+        "fields": [
+            {"name": "id", "type": "DataType.VARCHAR", "params": {"max_length": 128}},
+            {"name": "text", "type": "DataType.VARCHAR", "params": {"max_length": 65535}},
+            {"name": "embedding", "type": "DataType.FLOAT_VECTOR", "params": {"dim": 4}},
+        ]
+    }
+    status = create_collection(client, "docs", _schema_with_tags(dim=4))
+    assert status == "extended"
+    client.create_collection.assert_not_called()
+    client.drop_collection.assert_not_called()
+    client.add_collection_field.assert_called_once()
+    _, kwargs = client.add_collection_field.call_args
+    assert kwargs["collection_name"] == "docs"
+    assert kwargs["field_name"] == "tags"
+    assert kwargs["data_type"] == DataType.VARCHAR
+    assert kwargs["nullable"] is True
+    assert kwargs["max_length"] == 512
+
+
+def test_create_collection_still_raises_on_type_mismatch(mocker):
+    """Additive path must not mask genuine incompatibilities."""
+    client = mocker.Mock()
+    client.list_collections.return_value = ["docs"]
+    client.describe_collection.return_value = {
+        "fields": [
+            {"name": "id", "type": "DataType.VARCHAR", "params": {"max_length": 128}},
+            {"name": "text", "type": "DataType.VARCHAR", "params": {"max_length": 65535}},
+            {"name": "embedding", "type": "DataType.FLOAT_VECTOR", "params": {"dim": 999}},
+        ]
+    }
+    with pytest.raises(SchemaConflictError):
+        create_collection(client, "docs", _schema_with_tags(dim=4))
+    client.add_collection_field.assert_not_called()
+
+
+def test_create_collection_raises_on_field_dropped_from_plan(mocker):
+    """A field present in the live collection but missing from the new plan
+    is destructive — keep it fatal."""
+    client = mocker.Mock()
+    client.list_collections.return_value = ["docs"]
+    client.describe_collection.return_value = {
+        "fields": [
+            {"name": "id", "type": "DataType.VARCHAR", "params": {"max_length": 128}},
+            {"name": "text", "type": "DataType.VARCHAR", "params": {"max_length": 65535}},
+            {"name": "embedding", "type": "DataType.FLOAT_VECTOR", "params": {"dim": 4}},
+            {"name": "legacy", "type": "DataType.VARCHAR", "params": {"max_length": 32}},
+        ]
+    }
+    with pytest.raises(SchemaConflictError) as exc:
+        create_collection(client, "docs", _schema(dim=4))
+    assert any("legacy" in m for m in exc.value.payload["mismatches"])
+    client.add_collection_field.assert_not_called()


### PR DESCRIPTION
## Summary
- Classify schema diffs into additive (plan has a new field) vs fatal (type/param mismatch, or field dropped from plan)
- When only additive diffs remain, call `MilvusClient.add_collection_field(..., nullable=True)` per missing field and return a new `"extended"` status — no drop, no re-ingest
- Keep `SchemaConflictError` for genuinely incompatible diffs (type/dim/max_length mismatch, or fields dropped from the plan)

## Why
Before this change, adding a new extra field to a plan (e.g. a `tags` column on an image collection) hit `SchemaConflictError` inside `operations.create_collection`. The only way forward was to drop the collection and re-embed every document — the exact workflow shown in #3 where ~60k photos had to be re-indexed just to add one metadata field. pymilvus already exposes `add_collection_field` for nullable online field additions; launchpad just wasn't using it.

## Test plan
- [x] `uv run pytest tests/test_operations.py -v` — 8 passed (3 new cases: extend on missing field, still raise on type mismatch, still raise when plan drops a field)
- [x] `uv run pytest tests/ -q -m "not documents"` — 277 passed, 4 skipped, 2 deselected (PDF tests gated on optional dep)
- [ ] Manual: add a field to a plan against an existing populated collection; confirm only `add_collection_field` is called and vector data is preserved

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)