### PR TITLE
feat(launchpad): demo UI filter input, reranker toggle, metadata cards

### DIFF
--- a/skills/zilliz-launchpad/SKILL.md
+++ b/skills/zilliz-launchpad/SKILL.md
@@ -122,6 +122,8 @@ pnpm dev
 # open http://localhost:3000
 ```
 
+For text collections the demo UI exposes a Milvus filter-expression input (e.g. `year >= 2023`) and a reranker toggle (`Off` / `Default`, where `Default` follows the plan's recorded reranker). Result cards render every non-vector scalar field returned by the collection, so ingested metadata like `title` / `year` / `genre` shows up next to the chunk text without further work.
+
 ## Error envelopes
 
 Every CLI error arrives on stderr as a single-line JSON object:

--- a/skills/zilliz-launchpad/scripts/lib/ui.py
+++ b/skills/zilliz-launchpad/scripts/lib/ui.py
@@ -187,7 +187,7 @@ def _scalar_output_fields(plan: dict[str, Any]) -> list[str]:
         name = extra.get("name") if isinstance(extra, dict) else None
         if not isinstance(name, str) or not name or name in seen:
             continue
-        if name == vector_field or name == sparse_field:
+        if name in (vector_field, sparse_field):
             continue
         names.append(name)
         seen.add(name)

--- a/skills/zilliz-launchpad/scripts/lib/ui.py
+++ b/skills/zilliz-launchpad/scripts/lib/ui.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+from pymilvus.exceptions import MilvusException
 
 from .client import MilvusClient
 from .embeddings import embed_image_batch, embed_text_with_clip, make_embedder
@@ -167,6 +168,51 @@ class SearchRequest(BaseModel):
     query: str
     top_k: int = Field(default=10, ge=1, le=100)
     mode: Literal["dense", "sparse", "hybrid"] = "dense"
+    filter: str | None = None
+    rerank: str | None = None
+
+
+def _scalar_output_fields(plan: dict[str, Any]) -> list[str]:
+    """Schema scalar fields (pk + text + extra) excluding vector / sparse fields."""
+    schema = plan.get("schema") or {}
+    vector_field = schema.get("vector_field")
+    sparse_field = schema.get("sparse_field")
+    names: list[str] = []
+    seen: set[str] = set()
+    for candidate in (schema.get("primary_key"), schema.get("text_field")):
+        if isinstance(candidate, str) and candidate and candidate not in seen:
+            names.append(candidate)
+            seen.add(candidate)
+    for extra in schema.get("extra_fields") or []:
+        name = extra.get("name") if isinstance(extra, dict) else None
+        if not isinstance(name, str) or not name or name in seen:
+            continue
+        if name == vector_field or name == sparse_field:
+            continue
+        names.append(name)
+        seen.add(name)
+    return names
+
+
+def _resolve_rerank(plan: dict[str, Any], requested: str | None) -> str | None:
+    """Map the request's rerank value to a concrete reranker model name (or None)."""
+    if requested is None:
+        return None
+    value = requested.strip().lower()
+    if value in ("", "off"):
+        return None
+    if value == "default":
+        default = plan.get("reranker")
+        if not isinstance(default, str) or not default:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "no_default_reranker",
+                    "message": "Active plan has no default reranker configured.",
+                },
+            )
+        return default
+    return requested
 
 
 class Hit(BaseModel):
@@ -191,6 +237,7 @@ class InfoResponse(BaseModel):
     has_thumbnails: bool
     video_static_prefix: str | None = None
     data_shape: str | None = None
+    default_reranker: str | None = None
 
 
 @app.get("/health")
@@ -227,6 +274,7 @@ def info() -> InfoResponse:
         has_thumbnails=bool(_thumbnails()),
         video_static_prefix=_VIDEO_STATIC_PREFIX if modality == "video" else None,
         data_shape=data_shape,
+        default_reranker=(plan.get("reranker") if isinstance(plan.get("reranker"), str) else None),
     )
 
 
@@ -240,7 +288,9 @@ def search(req: SearchRequest) -> SearchResponse:
     plan = _plan()
     client = _client()
     embedder = _embedder()
-    text_field = plan["schema"]["text_field"]
+    output_fields = _scalar_output_fields(plan)
+    filter_expr = req.filter or None
+    rerank = _resolve_rerank(plan, req.rerank)
     try:
         if req.mode == "dense":
             hits = search_dense(
@@ -250,7 +300,9 @@ def search(req: SearchRequest) -> SearchResponse:
                 embedder,
                 top_k=req.top_k,
                 vector_field=plan["schema"]["vector_field"],
-                output_fields=[text_field],
+                filter=filter_expr,
+                output_fields=output_fields,
+                rerank=rerank,
             )
         elif req.mode == "sparse":
             hits = search_sparse(
@@ -259,7 +311,9 @@ def search(req: SearchRequest) -> SearchResponse:
                 req.query,
                 top_k=req.top_k,
                 sparse_field=plan["schema"].get("sparse_field") or "sparse",
-                output_fields=[text_field],
+                filter=filter_expr,
+                output_fields=output_fields,
+                rerank=rerank,
             )
         else:
             hits = search_hybrid(
@@ -270,12 +324,19 @@ def search(req: SearchRequest) -> SearchResponse:
                 top_k=req.top_k,
                 vector_field=plan["schema"]["vector_field"],
                 sparse_field=plan["schema"].get("sparse_field") or "sparse",
-                output_fields=[text_field],
+                filter=filter_expr,
+                output_fields=output_fields,
+                rerank=rerank,
             )
     except SparseUnavailable as e:
         raise HTTPException(status_code=400, detail=e.to_dict()) from e
     except LaunchpadError as e:
         raise HTTPException(status_code=400, detail=e.to_dict()) from e
+    except MilvusException as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "bad_filter", "message": str(e)},
+        ) from e
 
     return SearchResponse(
         mode=req.mode,

--- a/skills/zilliz-launchpad/scripts/ui/app/page.tsx
+++ b/skills/zilliz-launchpad/scripts/ui/app/page.tsx
@@ -21,6 +21,8 @@ export default function HomePage() {
   const [query, setQuery] = useState("");
   const [mode, setMode] = useState<SearchMode>("dense");
   const [topK, setTopK] = useState(5);
+  const [filter, setFilter] = useState("");
+  const [rerank, setRerank] = useState<"off" | "default">("off");
   const [hits, setHits] = useState<Hit[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,7 +47,13 @@ export default function HomePage() {
     setLoading(true);
     setError(null);
     try {
-      const resp = await searchSidecar({ query, mode: visual ? "dense" : mode, top_k: topK });
+      const resp = await searchSidecar({
+        query,
+        mode: visual ? "dense" : mode,
+        top_k: topK,
+        filter: !visual && filter ? filter : undefined,
+        rerank: !visual && rerank !== "off" ? rerank : undefined,
+      });
       setHits(resp.hits);
       setHasSearched(true);
     } catch (err: unknown) {
@@ -148,11 +156,25 @@ export default function HomePage() {
           required
         />
         {!visual && (
-          <select value={mode} onChange={(e) => setMode(e.target.value as SearchMode)}>
-            <option value="dense">Dense</option>
-            <option value="sparse">Sparse</option>
-            <option value="hybrid">Hybrid</option>
-          </select>
+          <>
+            <select value={mode} onChange={(e) => setMode(e.target.value as SearchMode)}>
+              <option value="dense">Dense</option>
+              <option value="sparse">Sparse</option>
+              <option value="hybrid">Hybrid</option>
+            </select>
+            <select
+              value={rerank}
+              onChange={(e) => setRerank(e.target.value as "off" | "default")}
+              title="Reranker"
+            >
+              <option value="off">Rerank: Off</option>
+              <option value="default" disabled={!info?.default_reranker}>
+                {info?.default_reranker
+                  ? `Rerank: Default (${info.default_reranker})`
+                  : "Rerank: Default (none configured)"}
+              </option>
+            </select>
+          </>
         )}
         <input
           type="number"
@@ -165,6 +187,15 @@ export default function HomePage() {
         <button type="submit" disabled={loading}>
           {loading ? "…" : "Search"}
         </button>
+        {!visual && (
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder='Filter expression (e.g. year >= 2023)'
+            style={{ flexBasis: "100%", minWidth: 200 }}
+          />
+        )}
         {visual && (
           <>
             <input
@@ -208,10 +239,30 @@ export default function HomePage() {
       ) : isImage ? (
         <ImageGrid hits={hits} loading={loading} error={error} hasSearched={hasSearched} />
       ) : (
-        <TextResults hits={hits} loading={loading} error={error} hasSearched={hasSearched} />
+        <TextResults
+          hits={hits}
+          loading={loading}
+          error={error}
+          hasSearched={hasSearched}
+          info={info}
+        />
       )}
     </main>
   );
+}
+
+const TEXT_FIELD_CANDIDATES = ["text", "body", "content", "chunk"] as const;
+
+function pickPrimaryText(fields: Hit["fields"]): { key: string | null; value: string | null } {
+  for (const key of TEXT_FIELD_CANDIDATES) {
+    const v = fields[key];
+    if (typeof v === "string" && v.length > 0) return { key, value: v };
+  }
+  // Fallback: first string-valued field
+  for (const [k, v] of Object.entries(fields)) {
+    if (typeof v === "string" && v.length > 0) return { key: k, value: v };
+  }
+  return { key: null, value: null };
 }
 
 function TextResults({
@@ -219,11 +270,13 @@ function TextResults({
   loading,
   error,
   hasSearched,
+  info,
 }: {
   hits: Hit[];
   loading: boolean;
   error: string | null;
   hasSearched: boolean;
+  info: InfoResponse | null;
 }) {
   if (loading) {
     return <p style={{ color: "#888", marginTop: "1.5rem" }}>Searching…</p>;
@@ -254,25 +307,62 @@ function TextResults({
         gap: "0.75rem",
       }}
     >
-      {hits.map((h) => (
-        <article
-          key={h.id}
-          style={{
-            padding: "1rem",
-            border: "1px solid #222",
-            borderRadius: 8,
-            background: "#0f0f0f",
-          }}
-        >
-          <header style={{ display: "flex", justifyContent: "space-between", color: "#888" }}>
-            <span>{h.id}</span>
-            <span>score: {h.score.toFixed(4)}</span>
-          </header>
-          <pre style={{ whiteSpace: "pre-wrap", marginTop: "0.5rem" }}>
-            {String(h.fields?.text ?? h.fields?.body ?? JSON.stringify(h.fields))}
-          </pre>
-        </article>
-      ))}
+      {hits.map((h) => {
+        const fields = h.fields ?? {};
+        const { key: textKey, value: textValue } = pickPrimaryText(fields);
+        const pk = info?.primary_key;
+        const metaEntries = Object.entries(fields).filter(([k, v]) => {
+          if (k === textKey) return false;
+          if (pk && k === pk) return false;
+          if (v === null || v === undefined) return false;
+          if (typeof v === "string" && v.length === 0) return false;
+          if (Array.isArray(v) || typeof v === "object") return false;
+          return true;
+        });
+        return (
+          <article
+            key={h.id}
+            style={{
+              padding: "1rem",
+              border: "1px solid #222",
+              borderRadius: 8,
+              background: "#0f0f0f",
+            }}
+          >
+            <header style={{ display: "flex", justifyContent: "space-between", color: "#888" }}>
+              <span>{h.id}</span>
+              <span>score: {h.score.toFixed(4)}</span>
+            </header>
+            {metaEntries.length > 0 && (
+              <div
+                style={{
+                  marginTop: "0.5rem",
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "0.5rem",
+                  color: "#9ca3af",
+                  fontSize: "0.85rem",
+                }}
+              >
+                {metaEntries.map(([k, v], i) => (
+                  <span key={k}>
+                    <span style={{ color: "#6b7280" }}>{k}:</span>{" "}
+                    <span style={{ color: "#d1d5db" }}>{String(v)}</span>
+                    {i < metaEntries.length - 1 && <span style={{ marginLeft: "0.5rem" }}>·</span>}
+                  </span>
+                ))}
+              </div>
+            )}
+            {textValue !== null ? (
+              <pre style={{ whiteSpace: "pre-wrap", marginTop: "0.5rem" }}>{textValue}</pre>
+            ) : metaEntries.length === 0 ? (
+              <pre style={{ whiteSpace: "pre-wrap", marginTop: "0.5rem" }}>
+                {JSON.stringify(fields)}
+              </pre>
+            ) : null}
+          </article>
+        );
+      })}
     </section>
   );
 }

--- a/skills/zilliz-launchpad/scripts/ui/lib/milvus-client.ts
+++ b/skills/zilliz-launchpad/scripts/ui/lib/milvus-client.ts
@@ -5,6 +5,8 @@ export interface SearchRequest {
   query: string;
   top_k?: number;
   mode?: SearchMode;
+  filter?: string;
+  rerank?: string;
 }
 
 export interface Hit {
@@ -44,6 +46,7 @@ export interface InfoResponse {
   has_thumbnails: boolean;
   video_static_prefix?: string | null;
   data_shape?: string | null;
+  default_reranker?: string | null;
 }
 
 export interface VideoFramesRequest {


### PR DESCRIPTION
## Summary

Closes #5. Three demo-value gaps in the Next.js demo UI:

- **Filter input** — new textbox for Milvus filter expressions (e.g. `year >= 2023`), passed through to `/search` as `SearchRequest.filter` and forwarded to `client.search(filter=…)`. Parse errors surface as HTTP 400 `bad_filter`.
- **Reranker toggle** — `Off` / `Default` select wires the already-implemented Cohere/BGE rerank path in `lib/search.py` to the UI. `/info` now advertises the plan's `default_reranker`; the `Default` option is disabled when no reranker is configured.
- **Metadata-rich cards** — sidecar now requests every scalar schema field via `output_fields` (excluding vector / sparse), and `TextResults` renders the non-text/non-pk scalars as a compact chip row above the primary text.

No new deps, no plan/collect schema changes, no breaking changes (request fields are optional).

## Test plan

- [x] `tsc --noEmit` clean in `scripts/ui`
- [x] `ast.parse` confirms `lib/ui.py` is valid
- [ ] Movies sample: cards show `title` / `year` / `genre`
- [ ] `year >= 2023` narrows results live
- [ ] Reranker `Default` visibly reorders top-k for a query where lexical and semantic disagree
- [ ] Plain text-only corpus (PDF/markdown): card layout unchanged when no extra scalars

🤖 Generated with [Claude Code](https://claude.com/claude-code)