### PR TITLE
feat(launchpad): explicit `execute --append` flow (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Skill edits the embedding section of `configure.json` in the active run dir, rer
 
 > *"I already ran the launchpad on `docs_v1.jsonl` last week. Now I have `docs_v2.jsonl` — append it to the same collection."*
 
-Skill reuses the previous run dir's plan (preserving schema) and runs only `execute --input docs_v2.jsonl`. If the new file's fields don't match the planned schema, it stops with `schema_conflict` and tells you how to resolve it.
+Skill runs `execute --append --run-dir <previous-run-dir> --input docs_v2.jsonl`. The append path reuses `plan.json` (no re-plan), confirms the live collection schema matches, and upserts only the new rows. Results land in a fresh `execute_append.json` artifact so the original `execute.json` stays untouched (and a second append produces `execute_append.2.json`, etc.). If the new file's fields don't match the planned schema, it stops with `schema_conflict` and tells you how to resolve it.
 
 ### 7. Recover from `schema_conflict`
 

--- a/skills/zilliz-launchpad/scripts/lib/phases/execute.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/execute.py
@@ -941,7 +941,9 @@ def _read_plan_or_raise(out_dir: Path) -> dict[str, Any]:
     return json.loads(plan_path.read_text(encoding="utf-8"))
 
 
-def _verify_existing_schema(client: PyMilvusClient, collection: str, plan_schema: dict[str, Any]) -> None:
+def _verify_existing_schema(
+    client: PyMilvusClient, collection: str, plan_schema: dict[str, Any]
+) -> None:
     """Raise SchemaConflictError if the live collection does not match the plan schema."""
     if not collection_exists(client, collection):
         raise SchemaConflictError(

--- a/skills/zilliz-launchpad/scripts/lib/phases/execute.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/execute.py
@@ -24,9 +24,22 @@ from ..embeddings import (
     make_embedder,
     make_image_embedder,
 )
-from ..errors import ClusterNotReadyError, LaunchpadError, MissingCredentialError
+from ..errors import (
+    ClusterNotReadyError,
+    InvalidProfileError,
+    LaunchpadError,
+    MissingCredentialError,
+    SchemaConflictError,
+)
 from ..ingest import ingest_documents
-from ..operations import build_basic_schema, create_collection, create_index, load_collection
+from ..operations import (
+    _classify_diff,
+    build_basic_schema,
+    collection_exists,
+    create_collection,
+    create_index,
+    load_collection,
+)
 from ..samples import load as load_sample
 from ..search import search_dense
 
@@ -902,4 +915,122 @@ def run_execute(
     (out_dir / "execute.json").write_text(
         json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8"
     )
+    return report
+
+
+def _next_append_artifact_path(out_dir: Path) -> Path:
+    """Return the next available execute_append[.N].json path."""
+    base = out_dir / "execute_append.json"
+    if not base.exists():
+        return base
+    n = 2
+    while True:
+        candidate = out_dir / f"execute_append.{n}.json"
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
+def _read_plan_or_raise(out_dir: Path) -> dict[str, Any]:
+    plan_path = out_dir / "plan.json"
+    if not plan_path.exists():
+        raise InvalidProfileError(
+            pointer=str(plan_path),
+            reason="plan.json is missing; run `plan` before `execute --append`",
+        )
+    return json.loads(plan_path.read_text(encoding="utf-8"))
+
+
+def _verify_existing_schema(client: PyMilvusClient, collection: str, plan_schema: dict[str, Any]) -> None:
+    """Raise SchemaConflictError if the live collection does not match the plan schema."""
+    if not collection_exists(client, collection):
+        raise SchemaConflictError(
+            collection=collection,
+            mismatches=[
+                f"collection '{collection}' does not exist; "
+                "run `execute` (without --append) first or pick the original run-dir",
+            ],
+        )
+    info = client.describe_collection(collection)
+    existing_fields = info.get("fields", [])
+    schema = _schema_from_plan(plan_schema)
+    additive, fatal = _classify_diff(existing_fields, schema)
+    if additive or fatal:
+        mismatches = [f"missing field: {f.name}" for f in additive] + fatal
+        mismatches.append(
+            "remediation: run `execute` (no --append) in a fresh run-dir, "
+            "or align your input to the existing schema"
+        )
+        raise SchemaConflictError(collection=collection, mismatches=mismatches)
+
+
+def run_execute_append(
+    *,
+    out_dir: Path,
+    input_path: str,
+) -> dict[str, Any]:
+    """Append rows from `input_path` to the collection described by `<out_dir>/plan.json`.
+
+    Reuses the existing collection: no create_collection, no create_index, no
+    load_collection. Schema must match plan.json exactly. Writes results to
+    `execute_append.json` (or a numbered sibling) and never touches `execute.json`.
+    """
+    plan = _read_plan_or_raise(out_dir)
+
+    if plan["embedding"].get("modality") == "image":
+        raise InvalidProfileError(
+            pointer="plan.embedding.modality",
+            reason="--append is only supported for text collections in this release",
+        )
+
+    started = time.monotonic()
+    client = MilvusClient(uri=plan["target_uri"])
+    _verify_existing_schema(client, plan["collection_name"], plan["schema"])
+
+    embedder = make_embedder(
+        plan["embedding"]["provider"],
+        plan["embedding"]["model"],
+        plan["embedding"]["dim"],
+    )
+    docs = []
+    path = Path(input_path)
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                docs.append(json.loads(line))
+
+    chunk_config = ChunkConfig(size=plan["chunking"]["size"], overlap=plan["chunking"]["overlap"])
+    extra_keys = tuple(f["name"] for f in plan["schema"]["extra_fields"])
+    stats = ingest_documents(
+        client,
+        plan["collection_name"],
+        docs,
+        embedder,
+        text_field=plan["schema"]["text_field"],
+        id_field=plan["schema"]["primary_key"],
+        vector_field=plan["schema"]["vector_field"],
+        chunk_config=chunk_config,
+        extra_field_keys=extra_keys,
+    )
+
+    report: dict[str, Any] = {
+        "phase": "append-complete",
+        "collection": plan["collection_name"],
+        "target_uri": plan["target_uri"],
+        "input_path": str(input_path),
+        "appended_rows": stats.documents,
+        "ingest": {
+            "documents": stats.documents,
+            "chunks": stats.chunks,
+            "batches": stats.batches,
+            "retries": stats.retries,
+        },
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+    }
+    out_path = _next_append_artifact_path(out_dir)
+    out_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    report["artifact_path"] = str(out_path)
     return report

--- a/skills/zilliz-launchpad/scripts/lib/phases/execute.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/execute.py
@@ -938,7 +938,8 @@ def _read_plan_or_raise(out_dir: Path) -> dict[str, Any]:
             pointer=str(plan_path),
             reason="plan.json is missing; run `plan` before `execute --append`",
         )
-    return json.loads(plan_path.read_text(encoding="utf-8"))
+    data: dict[str, Any] = json.loads(plan_path.read_text(encoding="utf-8"))
+    return data
 
 
 def _verify_existing_schema(

--- a/skills/zilliz-launchpad/scripts/zilliz_ops.py
+++ b/skills/zilliz-launchpad/scripts/zilliz_ops.py
@@ -173,8 +173,39 @@ def execute(
         "--frame-progress",
         help="Emit one log line per frame batch during video ingest (noisy).",
     ),
+    append: bool = typer.Option(
+        False,
+        "--append",
+        help="Append --input rows to the run-dir's existing collection; writes execute_append.json",
+    ),
 ) -> None:
     """Phase 4 — apply plan and start UI sidecar."""
+    if append:
+        if run_dir is None or input is None:
+            print(
+                json.dumps(
+                    {
+                        "code": "missing_input",
+                        "message": "--append requires both --run-dir and --input",
+                    }
+                ),
+                file=sys.stderr,
+            )
+            raise typer.Exit(code=2)
+        out = resolve_run_dir(run_dir)
+        try:
+            report = phase_execute.run_execute_append(
+                out_dir=out,
+                input_path=str(input),
+            )
+        except LaunchpadError as e:
+            _fail(e)
+        typer.echo(f"run-dir: {out}")
+        typer.echo(f"collection: {report['collection']}")
+        typer.echo(f"appended_rows: {report['appended_rows']}")
+        typer.echo(f"artifact: {report['artifact_path']}")
+        return
+
     if prefetch_models:
         from lib.embeddings import prefetch_clip
 

--- a/tests/test_execute_append.py
+++ b/tests/test_execute_append.py
@@ -1,0 +1,146 @@
+"""Unit and integration coverage for the `execute --append` flow."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _write_plan(run_dir: Path, dim: int = 4) -> None:
+    plan = {
+        "target_uri": "http://localhost:19530",
+        "collection_name": "movies_append_test",
+        "schema": {
+            "primary_key": "id",
+            "text_field": "text",
+            "vector_field": "embedding",
+            "dim": dim,
+            "extra_fields": [],
+            "sparse_field": None,
+        },
+        "embedding": {"provider": "openai", "model": "text-embedding-3-small", "dim": dim},
+        "index": {"type": "HNSW", "metric": "COSINE", "params": {"M": 16, "efConstruction": 128}},
+        "chunking": {"size": 512, "overlap": 64},
+        "sparse_enabled": False,
+    }
+    (run_dir / "plan.json").write_text(json.dumps(plan), encoding="utf-8")
+
+
+def test_invalid_profile_when_plan_missing(tmp_path: Path):
+    from lib.errors import InvalidProfileError
+    from lib.phases.execute import run_execute_append
+
+    (tmp_path / "new.jsonl").write_text("", encoding="utf-8")
+    with pytest.raises(InvalidProfileError) as exc:
+        run_execute_append(out_dir=tmp_path, input_path=str(tmp_path / "new.jsonl"))
+    assert "plan.json" in exc.value.message
+
+
+def test_next_append_artifact_path_numbering(tmp_path: Path):
+    from lib.phases.execute import _next_append_artifact_path
+
+    assert _next_append_artifact_path(tmp_path) == tmp_path / "execute_append.json"
+    (tmp_path / "execute_append.json").write_text("{}", encoding="utf-8")
+    assert _next_append_artifact_path(tmp_path) == tmp_path / "execute_append.2.json"
+    (tmp_path / "execute_append.2.json").write_text("{}", encoding="utf-8")
+    assert _next_append_artifact_path(tmp_path) == tmp_path / "execute_append.3.json"
+
+
+def test_schema_conflict_on_dim_mismatch(tmp_path: Path, monkeypatch):
+    """Live collection schema differs from plan → SchemaConflictError with field detail."""
+    from lib import phases
+    from lib.errors import SchemaConflictError
+    from lib.phases.execute import run_execute_append
+
+    _write_plan(tmp_path, dim=8)  # plan says dim=8
+    (tmp_path / "new.jsonl").write_text("", encoding="utf-8")
+
+    class FakeClient:
+        def list_collections(self):
+            return ["movies_append_test"]
+
+        def describe_collection(self, name):
+            # Live schema has dim=4 — mismatch.
+            return {
+                "fields": [
+                    {"name": "id", "type": "DataType.VARCHAR", "params": {"max_length": 128}},
+                    {"name": "text", "type": "DataType.VARCHAR", "params": {"max_length": 65535}},
+                    {"name": "embedding", "type": "DataType.FLOAT_VECTOR", "params": {"dim": 4}},
+                ]
+            }
+
+    monkeypatch.setattr(phases.execute, "MilvusClient", lambda uri: FakeClient())
+    with pytest.raises(SchemaConflictError) as exc:
+        run_execute_append(out_dir=tmp_path, input_path=str(tmp_path / "new.jsonl"))
+    assert any("dim" in m for m in exc.value.payload["mismatches"])
+    # original execute.json must remain absent (we never wrote it)
+    assert not (tmp_path / "execute.json").exists()
+
+
+def test_schema_conflict_when_collection_missing(tmp_path: Path, monkeypatch):
+    from lib import phases
+    from lib.errors import SchemaConflictError
+    from lib.phases.execute import run_execute_append
+
+    _write_plan(tmp_path)
+    (tmp_path / "new.jsonl").write_text("", encoding="utf-8")
+
+    class FakeClient:
+        def list_collections(self):
+            return []
+
+    monkeypatch.setattr(phases.execute, "MilvusClient", lambda uri: FakeClient())
+    with pytest.raises(SchemaConflictError) as exc:
+        run_execute_append(out_dir=tmp_path, input_path=str(tmp_path / "new.jsonl"))
+    assert "does not exist" in " ".join(exc.value.payload["mismatches"])
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    os.environ.get("OPENAI_API_KEY") is None,
+    reason="OPENAI_API_KEY is required for real embedding calls",
+)
+def test_append_end_to_end(tmp_path: Path):
+    """Base ingest 20 rows → append 5 more → row count is 25 and original execute.json untouched."""
+    from lib.phases.collect import run_collect
+    from lib.phases.configure import run_configure
+    from lib.phases.execute import run_execute, run_execute_append
+    from lib.phases.plan import run_plan
+
+    run_collect(input_path=None, sample="movies", out_dir=tmp_path)
+    run_configure(
+        from_json=None,
+        out_dir=tmp_path,
+        overrides={"dataset_size": 20, "deployment_target": "local-standalone"},
+    )
+    run_plan(out_dir=tmp_path)
+    base = run_execute(
+        out_dir=tmp_path,
+        sample="movies",
+        input_path=None,
+        ui_port=8011,
+        start_ui=False,
+    )
+    assert base["ingest"]["documents"] == 20
+
+    # Snapshot bytes to assert immutability.
+    execute_json = tmp_path / "execute.json"
+    before = execute_json.read_bytes()
+
+    # Build a 5-row append input from the original sample's last 5 entries.
+    from lib.samples import load as load_sample
+
+    rows = list(load_sample("movies"))[-5:]
+    append_input = tmp_path / "docs_v2.jsonl"
+    append_input.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8"
+    )
+
+    report = run_execute_append(out_dir=tmp_path, input_path=str(append_input))
+    assert report["appended_rows"] == 5
+    assert (tmp_path / "execute_append.json").exists()
+    # Original execute.json byte-for-byte unchanged.
+    assert execute_json.read_bytes() == before

--- a/tests/test_execute_append.py
+++ b/tests/test_execute_append.py
@@ -135,9 +135,7 @@ def test_append_end_to_end(tmp_path: Path):
 
     rows = list(load_sample("movies"))[-5:]
     append_input = tmp_path / "docs_v2.jsonl"
-    append_input.write_text(
-        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8"
-    )
+    append_input.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
 
     report = run_execute_append(out_dir=tmp_path, input_path=str(append_input))
     assert report["appended_rows"] == 5


### PR DESCRIPTION
## Summary
- Adds a first-class `execute --append --run-dir <dir> --input new.jsonl` path that reuses the run dir's `plan.json`, verifies the live collection schema matches, and upserts new rows without recreating the collection or index.
- Results land in a separate `execute_append.json` artifact (numbered on subsequent appends) so the original `execute.json` is preserved byte-for-byte.
- README example #6 updated to use the new flag; schema mismatches still surface as `schema_conflict` with field detail and a remediation hint.

Closes #6.

## Test plan
- [x] `uv run pytest tests/` — 281 passed, 1 skipped (e2e, gated on `OPENAI_API_KEY`), 3 deselected
- [x] Unit tests cover plan-missing (`invalid_profile`), numbered-suffix logic, schema-mismatch on `dim`, and missing-collection cases
- [ ] Manual smoke against local Milvus standalone (deferred; e2e test exercises the same path when `OPENAI_API_KEY` is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)