### PR TITLE
feat(launchpad): add `plan diff` subcommand (#9)

### DIFF
--- a/skills/zilliz-launchpad/scripts/lib/phases/plan.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/plan.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import difflib
 import json
+import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -10,10 +12,10 @@ from typing import Any
 import typer
 
 from ..cli import fail as _cli_fail
-from ..errors import LaunchpadError
+from ..errors import CliErrorEnvelope, InvalidProfileError, LaunchpadError
 from ..optional_deps import detect_device_hint
 from ..profile import load_profile
-from ..run_dir import resolve_run_dir
+from ..run_dir import previous_run_dir, resolve_run_dir
 
 DEFAULT_EMBEDDING = {
     "provider": "openai",
@@ -400,14 +402,52 @@ def run_plan(*, out_dir: Path) -> dict[str, Any]:
     return plan.to_dict()
 
 
-def register(app: typer.Typer) -> None:
-    """Attach the Phase 3 ``plan`` subcommand to the shared app."""
+def _diff_fail(err: LaunchpadError) -> None:
+    """Emit the standard error envelope but exit with code 2.
 
-    @app.command()
+    `plan diff` reserves exit code 1 for the clean "the two plans differ"
+    signal (git-diff style), so failures must use a distinct non-1 code
+    while still emitting the same JSON envelope the skill's remediation
+    map consumes.
+    """
+    print(CliErrorEnvelope.from_error(err).to_json(), file=sys.stderr)
+    raise typer.Exit(code=2)
+
+
+def _resolve_for_diff(arg: str | None) -> Path:
+    """Resolve a `plan diff` run-dir argument as a structured error path."""
+    try:
+        return resolve_run_dir(arg)
+    except FileNotFoundError as exc:
+        raise InvalidProfileError(
+            pointer=str(arg) if arg is not None else "<latest>",
+            reason=str(exc),
+        ) from exc
+
+
+def _plan_md_lines(run: Path) -> list[str]:
+    plan_md = run / "plan.md"
+    if not plan_md.exists():
+        raise InvalidProfileError(
+            pointer=str(plan_md),
+            reason="missing plan.md — run `plan` in this run dir first",
+        )
+    return plan_md.read_text(encoding="utf-8").splitlines(keepends=True)
+
+
+def register(app: typer.Typer) -> None:
+    """Attach the Phase 3 ``plan`` command group to the shared app."""
+
+    plan_app = typer.Typer(help="Phase 3 — produce plan.{json,md}.")
+
+    @plan_app.callback(invoke_without_command=True)
     def plan(
+        ctx: typer.Context,
         run_dir: str | None = typer.Option(None, "--run-dir"),
     ) -> None:
         """Phase 3 — produce plan.{json,md}."""
+        if ctx.invoked_subcommand is not None:
+            return
         out = resolve_run_dir(run_dir)
         try:
             result = run_plan(out_dir=out)
@@ -416,3 +456,44 @@ def register(app: typer.Typer) -> None:
         typer.echo(f"run-dir: {out}")
         typer.echo(f"index: {result['index']['type']} {result['index']['params']}")
         typer.echo(f"sparse: {result['sparse_enabled']}")
+
+    @plan_app.command("diff")
+    def plan_diff(
+        run_a: str | None = typer.Argument(None, help="New side (default: latest run)."),
+        run_b: str | None = typer.Argument(None, help="Old side (default: the run before run-a)."),
+    ) -> None:
+        """Unified diff of two run dirs' plan.md (run-b → run-a).
+
+        Exit 0 = identical, 1 = differ, 2 = error.
+        """
+        try:
+            new_run = _resolve_for_diff(run_a)
+            if run_b is not None:
+                old_run = _resolve_for_diff(run_b)
+            else:
+                prev = previous_run_dir(new_run)
+                if prev is None:
+                    raise InvalidProfileError(
+                        pointer=str(new_run),
+                        reason="no previous run to compare against — "
+                        "run `plan` again after editing configure.json",
+                    )
+                old_run = prev
+            old_lines = _plan_md_lines(old_run)
+            new_lines = _plan_md_lines(new_run)
+        except LaunchpadError as e:
+            _diff_fail(e)
+
+        if old_lines == new_lines:
+            raise typer.Exit(code=0)
+
+        diff = difflib.unified_diff(
+            old_lines,
+            new_lines,
+            fromfile=f"{old_run.name}/plan.md",
+            tofile=f"{new_run.name}/plan.md",
+        )
+        sys.stdout.writelines(diff)
+        raise typer.Exit(code=1)
+
+    app.add_typer(plan_app, name="plan")

--- a/skills/zilliz-launchpad/scripts/lib/run_dir.py
+++ b/skills/zilliz-launchpad/scripts/lib/run_dir.py
@@ -34,6 +34,22 @@ def latest_run_dir() -> Path | None:
     return candidates[-1] if candidates else None
 
 
+def previous_run_dir(run: Path) -> Path | None:
+    """Return the run dir immediately preceding ``run`` in sorted order.
+
+    Sorting is by full directory name; the UTC-timestamp prefix dominates,
+    so this is "the run before this one chronologically." Returns ``None``
+    when ``run`` is the first run dir or is not among the known run dirs.
+    """
+    run = run.resolve()
+    candidates = sorted(p.resolve() for p in runs_root().iterdir() if p.is_dir())
+    try:
+        idx = candidates.index(run)
+    except ValueError:
+        return None
+    return candidates[idx - 1] if idx > 0 else None
+
+
 def resolve_run_dir(arg: str | None) -> Path:
     """`arg` may be `None` (→ latest), a relative path, or an absolute path."""
     if arg is None:

--- a/tests/test_plan_diff.py
+++ b/tests/test_plan_diff.py
@@ -1,0 +1,148 @@
+"""CLI tests for the `plan diff` subcommand."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import lib.run_dir as run_dir
+import pytest
+from typer.testing import CliRunner
+from zilliz_ops import app
+
+_RUNNER = CliRunner()
+_PLAN_MD = (
+    "# Launchpad Plan\n\n"
+    "- **Collection**: `launchpad_collection`\n\n"
+    "## Embedding\n"
+    "- Model: `text-embedding-3-small`\n"
+)
+
+
+@pytest.fixture
+def runs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "runs"
+    root.mkdir()
+    monkeypatch.setattr(run_dir, "_RUNS_ROOT", root)
+    return root
+
+
+def _mk_run(root: Path, name: str, plan_md: str | None = _PLAN_MD) -> Path:
+    p = root / name
+    p.mkdir()
+    if plan_md is not None:
+        (p / "plan.md").write_text(plan_md, encoding="utf-8")
+    return p
+
+
+def test_identical_plans_exit_0_no_output(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T09-00-00Z")
+    _mk_run(runs_root, "2026-05-18T10-00-00Z")
+    result = _RUNNER.invoke(app, ["plan", "diff"])
+    assert result.exit_code == 0
+    assert result.stdout == ""
+
+
+def test_differing_plans_exit_1_with_unified_markers(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T09-00-00Z")
+    _mk_run(
+        runs_root,
+        "2026-05-18T10-00-00Z",
+        _PLAN_MD.replace("text-embedding-3-small", "voyage-3"),
+    )
+    result = _RUNNER.invoke(app, ["plan", "diff"])
+    assert result.exit_code == 1
+    out = result.stdout
+    assert "--- 2026-05-18T09-00-00Z/plan.md" in out
+    assert "+++ 2026-05-18T10-00-00Z/plan.md" in out
+    assert "-- Model: `text-embedding-3-small`" in out
+    assert "+- Model: `voyage-3`" in out
+
+
+def test_no_arg_resolves_latest_vs_previous(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T08-00-00Z", _PLAN_MD.replace("small", "OLDEST"))
+    _mk_run(runs_root, "2026-05-18T09-00-00Z")  # previous (old side)
+    _mk_run(
+        runs_root,
+        "2026-05-18T10-00-00Z",
+        _PLAN_MD.replace("text-embedding-3-small", "voyage-3"),
+    )  # latest (new side)
+    result = _RUNNER.invoke(app, ["plan", "diff"])
+    assert result.exit_code == 1
+    # Diff is latest vs the immediately-preceding run, not the oldest.
+    assert "--- 2026-05-18T09-00-00Z/plan.md" in result.stdout
+    assert "+++ 2026-05-18T10-00-00Z/plan.md" in result.stdout
+    assert "OLDEST" not in result.stdout
+
+
+def test_single_arg_is_run_a_with_defaulted_predecessor(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T09-00-00Z")  # predecessor → run-b
+    _mk_run(
+        runs_root,
+        "2026-05-18T10-00-00Z",
+        _PLAN_MD.replace("text-embedding-3-small", "voyage-3"),
+    )
+    _mk_run(runs_root, "2026-05-18T11-00-00Z", _PLAN_MD.replace("small", "NEWER"))
+    result = _RUNNER.invoke(app, ["plan", "diff", "2026-05-18T10-00-00Z"])
+    assert result.exit_code == 1
+    assert "--- 2026-05-18T09-00-00Z/plan.md" in result.stdout
+    assert "+++ 2026-05-18T10-00-00Z/plan.md" in result.stdout
+    assert "NEWER" not in result.stdout
+
+
+def test_two_explicit_args_no_defaulting(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T09-00-00Z")
+    _mk_run(
+        runs_root,
+        "2026-05-18T10-00-00Z",
+        _PLAN_MD.replace("text-embedding-3-small", "voyage-3"),
+    )
+    result = _RUNNER.invoke(app, ["plan", "diff", "2026-05-18T10-00-00Z", "2026-05-18T09-00-00Z"])
+    assert result.exit_code == 1
+    assert "+++ 2026-05-18T10-00-00Z/plan.md" in result.stdout
+
+
+def _assert_error_envelope(result, code: str) -> None:
+    assert result.exit_code == 2  # non-1: distinct from the "differ" signal
+    payload = json.loads(result.stderr.strip().splitlines()[-1])
+    assert payload["code"] == code
+
+
+def test_missing_run_dir_errors(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T09-00-00Z")
+    result = _RUNNER.invoke(app, ["plan", "diff", "does-not-exist"])
+    _assert_error_envelope(result, "invalid_profile")
+
+
+def test_missing_plan_md_errors(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T09-00-00Z", plan_md=None)
+    _mk_run(runs_root, "2026-05-18T10-00-00Z")
+    result = _RUNNER.invoke(app, ["plan", "diff"])
+    _assert_error_envelope(result, "invalid_profile")
+
+
+def test_single_run_no_previous_errors(runs_root: Path) -> None:
+    _mk_run(runs_root, "2026-05-18T09-00-00Z")
+    result = _RUNNER.invoke(app, ["plan", "diff"])
+    _assert_error_envelope(result, "invalid_profile")
+
+
+def test_bare_plan_still_runs_phase_3(runs_root: Path) -> None:
+    """Sub-app conversion must not change `plan`'s standalone behavior."""
+    from lib.phases.collect import run_collect
+    from lib.phases.configure import run_configure
+
+    run = runs_root / "2026-05-18T12-00-00Z"
+    run.mkdir()
+    run_collect(input_path=None, sample="movies", out_dir=run)
+    run_configure(
+        from_json=None,
+        out_dir=run,
+        overrides={"dataset_size": 20, "deployment_target": "local-standalone"},
+    )
+    result = _RUNNER.invoke(app, ["plan", "--run-dir", "2026-05-18T12-00-00Z"])
+    assert result.exit_code == 0
+    assert "index:" in result.stdout
+    assert "sparse:" in result.stdout
+    assert (run / "plan.json").exists()
+    assert (run / "plan.md").exists()

--- a/tests/test_run_dir.py
+++ b/tests/test_run_dir.py
@@ -1,0 +1,48 @@
+"""Unit tests for run-dir ordering helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import lib.run_dir as run_dir
+import pytest
+
+
+@pytest.fixture
+def runs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "runs"
+    root.mkdir()
+    monkeypatch.setattr(run_dir, "_RUNS_ROOT", root)
+    return root
+
+
+def _mk(root: Path, name: str) -> Path:
+    p = root / name
+    p.mkdir()
+    return p
+
+
+def test_previous_run_dir_returns_predecessor(runs_root: Path) -> None:
+    a = _mk(runs_root, "2026-05-18T09-00-00Z")
+    b = _mk(runs_root, "2026-05-18T10-00-00Z")
+    c = _mk(runs_root, "2026-05-18T11-00-00Z")
+    assert run_dir.previous_run_dir(c) == b
+    assert run_dir.previous_run_dir(b) == a
+
+
+def test_previous_run_dir_first_run_returns_none(runs_root: Path) -> None:
+    a = _mk(runs_root, "2026-05-18T09-00-00Z")
+    _mk(runs_root, "2026-05-18T10-00-00Z")
+    assert run_dir.previous_run_dir(a) is None
+
+
+def test_previous_run_dir_single_run_returns_none(runs_root: Path) -> None:
+    only = _mk(runs_root, "2026-05-18T09-00-00Z")
+    assert run_dir.previous_run_dir(only) is None
+
+
+def test_previous_run_dir_unknown_run_returns_none(runs_root: Path, tmp_path: Path) -> None:
+    _mk(runs_root, "2026-05-18T09-00-00Z")
+    stranger = tmp_path / "not-a-run"
+    stranger.mkdir()
+    assert run_dir.previous_run_dir(stranger) is None


### PR DESCRIPTION
Closes #9.

## Why

README example #5 says the skill "reruns `plan` and diffs the new `plan.md` against the previous one," but there was no `plan diff` subcommand — the agent had to roll its own diff. This makes the CLI back the claim (Option A from the issue).

## What

`zilliz_ops.py plan diff [run-a] [run-b]` — unified text diff of two run dirs' `plan.md`:

- **No args**: latest run (new, `+++`) vs. previous run (old, `---`)
- **One arg**: that `run-a` vs. its predecessor by sorted run-dir order
- **Two args**: explicit `run-a` / `run-b`, no defaulting
- Run-dir args accept the same forms as `--run-dir` (bare name / relative / absolute)
- Stdlib `difflib`, no new dependencies

### Exit codes

| Code | Meaning |
|------|---------|
| `0`  | `plan.md` files identical (no output) |
| `1`  | files differ (unified diff on stdout) |
| `2`  | error (missing run dir / missing `plan.md` / no previous run) |

`plan` is converted to a Typer sub-app with an `invoke_without_command` callback, so bare `plan` keeps its exact Phase 3 behavior (covered by a regression test).

### Design note worth a look

Issue acceptance + the synced spec require error exits to be **distinct from the "differ" signal**. `lib/cli.fail` hardcodes `Exit(code=1)`, which would collide with "differ = 1". Resolution: errors reuse the same `CliErrorEnvelope` JSON (so the skill's error-code remediation map still works) but exit **2** via a local `_diff_fail` helper. If you'd rather errors also exit 1 and be disambiguated purely by stderr, that's a one-line change.

## Testing

- `tests/test_run_dir.py` (4) + `tests/test_plan_diff.py` (9) — all pass
- Full suite: 307 passed (2 pre-existing `test_collect_pdf.py` failures are unrelated — missing optional PDF dep in-env, fail on a clean tree too)
- ruff + mypy clean on changed files
- Manual run reproduced the README #5 scenario (switch to `voyage-3`, rerun, diff) with correct exit 0/1/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)