### PR TITLE
chore: add pre-commit hook running ruff/mypy/pytest

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); printf '%s' \"$cmd\" | grep -qE 'git[[:space:]]+commit' || exit 0; root=$(git rev-parse --show-toplevel) || exit 0; out=$(cd \"$root\" && uv run ruff check . && uv run ruff format --check . && uv run mypy skills/zilliz-launchpad/scripts && uv run pytest -m \"not cloud and not e2e and not multimodal and not documents\" 2>&1) || { printf 'Pre-commit checks failed. Fix the issues below, then commit again (git commit will re-run these checks):\\n\\n%s\\n' \"$out\" >&2; exit 2; }",
+            "timeout": 600,
+            "statusMessage": "Pre-commit checks (ruff / mypy / pytest)..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ skills/zilliz-launchpad/scripts/volumes/
 .vscode/
 
 openspec/
-.claude/
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
## What

Adds a team-shared `PreToolUse` Bash hook in `.claude/settings.json` that runs the project's quality gate before any `git commit` (including chained `git add -A && git commit`):

1. `uv run ruff check .`
2. `uv run ruff format --check .`
3. `uv run mypy skills/zilliz-launchpad/scripts`
4. `uv run pytest -m "not cloud and not e2e and not multimodal and not documents"`

On failure the hook exits non-zero, **blocking the commit** and feeding the output back so the issues are fixed and the commit retried — a natural fix-then-rerun loop. Non-commit Bash commands are skipped with zero overhead.

Also un-ignores `.claude/settings.json` in `.gitignore` (`.claude/*` + `!.claude/settings.json`) so the hook is shared with the team; `settings.local.json`, `skills/`, `commands/` stay ignored.

## Verification

- git-commit detection: non-commit skipped, direct commit matched, chained `git add && git commit` matched
- Full check chain green on current tree (304 passed, 1 skipped, ~8s)
- `settings.json` JSON + hook schema validated with `jq -e`

## Note for reviewers

Each developer must open `/hooks` once (or restart Claude Code) after pulling for the new config file to load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)