### PR TITLE
feat(launchpad): populate cost/query column in eval_report.md (#10)

### DIFF
--- a/skills/zilliz-launchpad/references/knowledge/dense_embedding_models.md
+++ b/skills/zilliz-launchpad/references/knowledge/dense_embedding_models.md
@@ -2,14 +2,17 @@
 
 API-only providers supported in the MVP (no local / torch models).
 
-| Provider | Recommended model          | Dim  | Notes |
-| ---      | ---                        | ---  | --- |
-| openai   | `text-embedding-3-small`   | 1536 | Default. Balanced cost/quality. |
-| openai   | `text-embedding-3-large`   | 3072 | Higher quality, 5× cost. |
-| voyage   | `voyage-3`                 | 1024 | Strong on retrieval; reasonably priced. |
-| voyage   | `voyage-3-large`           | 2048 | Top-of-line quality. |
-| cohere   | `embed-english-v3.0`       | 1024 | Solid English; `embed-multilingual-v3.0` for non-English. |
-| zilliz-byom | (user-chosen)           | (user-chosen) | For self-hosted / private endpoints. |
+| Provider | Recommended model          | Dim  | USD / 1M tokens | Notes |
+| ---      | ---                        | ---  | --- | --- |
+| openai   | `text-embedding-3-small`   | 1536 | 0.02 | Default. Balanced cost/quality. |
+| openai   | `text-embedding-3-large`   | 3072 | 0.13 | Higher quality, 5× cost. |
+| voyage   | `voyage-3`                 | 1024 | 0.06 | Strong on retrieval; reasonably priced. |
+| voyage   | `voyage-3-large`           | 2048 | 0.18 | Top-of-line quality. |
+| cohere   | `embed-english-v3.0`       | 1024 | 0.10 | Solid English; `embed-multilingual-v3.0` for non-English. |
+| zilliz-byom | (user-chosen)           | (user-chosen) | 0 | For self-hosted / private endpoints (no per-call API spend). |
+
+> **Prices are advisory estimates** in USD per 1M input tokens, used only to populate the
+> `cost/query` column of `eval_report.md`. Edit this one file to add a model or refresh a price.
 
 ## How to pick
 

--- a/skills/zilliz-launchpad/references/knowledge/reranker_guide.md
+++ b/skills/zilliz-launchpad/references/knowledge/reranker_guide.md
@@ -4,10 +4,13 @@ A reranker takes the top `k*3` raw candidates from vector search and reorders th
 
 ## Supported in MVP
 
-| Adapter id                 | Backend             | Cost surface |
-| ---                        | ---                 | --- |
-| `cohere-rerank-3`          | Cohere Rerank 3     | Paid per 1k docs; 1k req/min free tier. |
-| `bge-reranker-v2-m3`       | Zilliz BYOM endpoint | Self-hosted; you control cost. |
+| Adapter id                 | Backend             | USD / 1k searches | Cost surface |
+| ---                        | ---                 | --- | --- |
+| `cohere-rerank-3`          | Cohere Rerank 3     | 2.00 | Paid per 1k docs; 1k req/min free tier. |
+| `bge-reranker-v2-m3`       | Zilliz BYOM endpoint | 0 | Self-hosted; you control cost (no per-call API spend). |
+
+> **Prices are advisory estimates** in USD per 1k rerank searches, used only to populate the
+> `cost/query` column of `eval_report.md`. Edit this one file to add an adapter or refresh a price.
 
 ## When to enable
 

--- a/skills/zilliz-launchpad/scripts/lib/phases/evaluate.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/evaluate.py
@@ -36,6 +36,7 @@ from ..evaluator import (
     compute_retrieval_metrics,
     derive_queries_from_corpus,
 )
+from ..pricing import cost_per_query as _cost_per_query
 from ..run_dir import load_plan, preflight_execute_artifact, resolve_run_dir
 from ..search import search_dense, search_hybrid, search_image_to_image
 from ..vision_judge import caption_images, is_vision_capable
@@ -671,6 +672,7 @@ class _RowResult:
     retrieval: dict[str, float] = field(default_factory=dict)
     latency: dict[str, float] = field(default_factory=dict)
     rag: dict[str, float] | None = None
+    cost: dict[str, float] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -678,6 +680,7 @@ class _RowResult:
             "retrieval": self.retrieval,
             "latency": self.latency,
             "rag": self.rag,
+            "cost": self.cost,
         }
 
 
@@ -751,7 +754,16 @@ def _evaluate_single(
     )
     rag = _maybe_rag(judge, queries, retrieved_texts) if judge else None
 
-    row = _RowResult(label=label, retrieval=retrieval, latency=latency, rag=rag)
+    cost_val = _cost_per_query(
+        queries=[q.query for q in queries],
+        provider=plan["embedding"]["provider"],
+        model=plan["embedding"]["model"],
+        reranker=plan.get("reranker"),
+        top_k=_TOP_K,
+    )
+    cost = {"cost_per_query": cost_val} if cost_val is not None else None
+
+    row = _RowResult(label=label, retrieval=retrieval, latency=latency, rag=rag, cost=cost)
     return row.to_dict()
 
 
@@ -1223,6 +1235,7 @@ def _build_report(
     derived: bool,
 ) -> dict[str, Any]:
     report: dict[str, Any] = {
+        "cost_metrics": base_row.get("cost"),
         "derived": derived,
         "latency_metrics": base_row["latency"],
         "query_count": len(queries),
@@ -1265,10 +1278,13 @@ def _render_markdown(report: dict[str, Any]) -> str:
             report["retrieval_metrics"],
             report["latency_metrics"],
             report["rag_metrics"],
+            report.get("cost_metrics"),
         )
     )
     for v in report["variants"]:
-        lines.append(_decision_row(v["label"], v["retrieval"], v["latency"], v["rag"]))
+        lines.append(
+            _decision_row(v["label"], v["retrieval"], v["latency"], v["rag"], v.get("cost"))
+        )
 
     if report["derived"]:
         lines += [
@@ -1291,15 +1307,16 @@ def _decision_row(
     retrieval: dict[str, float],
     latency: dict[str, float],
     rag: dict[str, float] | None,
+    cost: dict[str, float] | None,
 ) -> str:
     recall = retrieval.get("recall@10")
     p95 = latency.get("p95_ms")
     faith = (rag or {}).get("faithfulness")
+    cpq = (cost or {}).get("cost_per_query")
     recall_cell = f"{recall:.3f}" if recall is not None else "—"
     p95_cell = f"{p95:.1f}" if p95 is not None else "—"
     faith_cell = f"{faith:.3f}" if faith is not None else "—"
-    # cost/query is a placeholder until Phase 5 wires a real cost estimator
-    cost_cell = "—"
+    cost_cell = f"${cpq:.6f}" if cpq is not None else "—"
     return f"| {label} | {recall_cell} | {p95_cell} | {faith_cell} | {cost_cell} |"
 
 

--- a/skills/zilliz-launchpad/scripts/lib/pricing.py
+++ b/skills/zilliz-launchpad/scripts/lib/pricing.py
@@ -1,0 +1,184 @@
+"""Per-query cost estimation for the Phase 5 decision table.
+
+Prices live in the user-facing knowledge markdown so adding or repricing a
+model is a one-file edit (issue #10):
+  - references/knowledge/dense_embedding_models.md  (`USD / 1M tokens`)
+  - references/knowledge/reranker_guide.md           (`USD / 1k searches`)
+
+Token counts are estimated with the project's character heuristic
+(`len(text) / 4`, matching chunking.py) rather than per-SDK usage — uniform
+across providers, dependency-free, and precise enough to rank variants.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections.abc import Sequence
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_KNOWLEDGE_DIR = Path(__file__).resolve().parents[2] / "references" / "knowledge"
+_EMBEDDING_FILE = _KNOWLEDGE_DIR / "dense_embedding_models.md"
+_RERANKER_FILE = _KNOWLEDGE_DIR / "reranker_guide.md"
+
+_CHARS_PER_TOKEN = 4  # matches chunking.py's approximation
+
+# Deduplicates the "model not in price table" warning so many variants /
+# repeated runs warn once per unknown model rather than spamming the log.
+_WARNED: set[str] = set()
+
+
+def reset_missing_warnings() -> None:
+    """Clear the warn-once dedup set (used by tests)."""
+    _WARNED.clear()
+
+
+def _warn_missing(what: str) -> None:
+    if what in _WARNED:
+        return
+    _WARNED.add(what)
+    logger.warning(
+        "%s is not in the price table; cost/query will show '—'. "
+        "Add a row to the knowledge markdown to price it.",
+        what,
+    )
+
+
+def estimate_tokens(text: str) -> int:
+    """Approximate input tokens as ceil(len(text) / 4)."""
+    return math.ceil(len(text) / _CHARS_PER_TOKEN)
+
+
+def _split_row(line: str) -> list[str]:
+    cells = line.strip().strip("|").split("|")
+    return [c.strip() for c in cells]
+
+
+def _is_separator(cells: Sequence[str]) -> bool:
+    return all(set(c) <= {"-", ":", " "} and c for c in cells)
+
+
+def _backtick_code(cell: str) -> str | None:
+    """Return the code inside the first backtick pair, or None if unquoted.
+
+    An unquoted model cell (e.g. `(user-chosen)`) marks a provider-level
+    wildcard row.
+    """
+    m = re.search(r"`([^`]+)`", cell)
+    return m.group(1) if m else None
+
+
+def _parse_price_table(
+    path: Path, *, key_header: str, price_header: str
+) -> tuple[dict[tuple[str, str], float], dict[str, float], dict[str, float]]:
+    """Parse one markdown price table.
+
+    Returns (exact, provider_wildcard, by_code):
+      - exact:    {(provider_lower, code): price}
+      - wildcard: {provider_lower: price}  (rows with an unquoted key cell)
+      - by_code:  {code: price}            (single-key tables, e.g. rerankers)
+    """
+    exact: dict[tuple[str, str], float] = {}
+    wildcard: dict[str, float] = {}
+    by_code: dict[str, float] = {}
+    if not path.exists():
+        return exact, wildcard, by_code
+
+    header: list[str] | None = None
+    key_idx = price_idx = provider_idx = -1
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip().startswith("|"):
+            continue
+        cells = _split_row(raw)
+        if header is None:
+            if any(key_header in c for c in cells) and any(price_header in c for c in cells):
+                header = cells
+                key_idx = next(i for i, c in enumerate(cells) if key_header in c)
+                price_idx = next(i for i, c in enumerate(cells) if price_header in c)
+                provider_idx = next((i for i, c in enumerate(cells) if c.lower() == "provider"), -1)
+            continue
+        if _is_separator(cells):
+            continue
+        if max(key_idx, price_idx, provider_idx) >= len(cells):
+            continue
+        try:
+            price = float(cells[price_idx])
+        except ValueError:
+            continue
+        code = _backtick_code(cells[key_idx])
+        if provider_idx >= 0:
+            provider = cells[provider_idx].lower()
+            if code is None:
+                wildcard[provider] = price
+            else:
+                exact[(provider, code)] = price
+        elif code is not None:
+            by_code[code] = price
+    return exact, wildcard, by_code
+
+
+@lru_cache(maxsize=1)
+def _embedding_prices() -> tuple[dict[tuple[str, str], float], dict[str, float]]:
+    exact, wildcard, _ = _parse_price_table(
+        _EMBEDDING_FILE, key_header="Recommended model", price_header="USD / 1M tokens"
+    )
+    return exact, wildcard
+
+
+@lru_cache(maxsize=1)
+def _reranker_prices() -> dict[str, float]:
+    _, _, by_code = _parse_price_table(
+        _RERANKER_FILE, key_header="Adapter id", price_header="USD / 1k searches"
+    )
+    return by_code
+
+
+def embedding_price_per_1m(provider: str, model: str) -> float | None:
+    """USD per 1M input tokens for provider/model, or None if unpriced."""
+    exact, wildcard = _embedding_prices()
+    key = (provider.lower(), model)
+    if key in exact:
+        return exact[key]
+    return wildcard.get(provider.lower())
+
+
+def reranker_price_per_1k(adapter: str) -> float | None:
+    """USD per 1k rerank searches for adapter, or None if unpriced."""
+    return _reranker_prices().get(adapter)
+
+
+def cost_per_query(
+    *,
+    queries: Sequence[str],
+    provider: str,
+    model: str,
+    reranker: str | None,
+    top_k: int,
+) -> float | None:
+    """Estimated USD cost of one query for this resolved plan.
+
+    Embedding cost uses mean estimated tokens across the query set; reranker
+    cost uses the `top_k * 3` candidate fan-out priced per 1k searches.
+    Returns None (→ '—' cell) if the embedding model or an enabled reranker
+    is missing from the price table, warning once per unknown model.
+    """
+    embed_price = embedding_price_per_1m(provider, model)
+    if embed_price is None:
+        _warn_missing(f"embedding {provider}/{model}")
+        return None
+
+    mean_tokens = sum(estimate_tokens(q) for q in queries) / len(queries) if queries else 0.0
+    cost = mean_tokens / 1_000_000 * embed_price
+
+    if reranker:
+        rr_price = reranker_price_per_1k(reranker)
+        if rr_price is None:
+            _warn_missing(f"reranker {reranker}")
+            return None
+        cost += (top_k * 3) / 1000 * rr_price
+
+    return cost

--- a/tests/test_evaluate_cost.py
+++ b/tests/test_evaluate_cost.py
@@ -1,0 +1,143 @@
+"""Report-shape tests for the populated cost/query column (issue #10).
+
+These exercise the pure report-assembly functions without Milvus.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from lib import pricing
+from lib.evaluator import QueryWithExpectedIds
+from lib.phases.evaluate import (
+    _build_report,
+    _decision_row,
+    _render_markdown,
+    _RowResult,
+)
+
+
+def _row(label: str, *, cost: dict[str, float] | None) -> dict:
+    return _RowResult(
+        label=label,
+        retrieval={"recall@10": 0.5},
+        latency={"p95_ms": 12.0},
+        rag=None,
+        cost=cost,
+    ).to_dict()
+
+
+def test_rowresult_to_dict_includes_cost():
+    d = _RowResult(label="base", cost={"cost_per_query": 0.01}).to_dict()
+    assert d["cost"] == {"cost_per_query": 0.01}
+
+
+def test_rowresult_cost_defaults_to_none():
+    assert _RowResult(label="base").to_dict()["cost"] is None
+
+
+def test_decision_row_renders_cost_when_present():
+    line = _decision_row(
+        "base", {"recall@10": 0.5}, {"p95_ms": 12.0}, None, {"cost_per_query": 0.06}
+    )
+    assert "$0.060000" in line
+
+
+def test_decision_row_renders_dash_when_cost_none():
+    line = _decision_row("base", {"recall@10": 0.5}, {"p95_ms": 12.0}, None, None)
+    assert line.rstrip().endswith("| — |")
+
+
+def test_build_report_and_markdown_carry_base_and_variant_cost(tmp_path: Path):
+    queries = [QueryWithExpectedIds(query="hi", relevant_ids=("1",))]
+    base = _row("base", cost={"cost_per_query": 0.01})
+    variant = _row("voyage", cost={"cost_per_query": 0.02})
+    variant["overrides"] = {"embedding": {"provider": "voyage"}}
+
+    report = _build_report(
+        out_dir=tmp_path,
+        queries=queries,
+        base_row=base,
+        variant_rows=[variant],
+        derived=False,
+    )
+
+    assert report["cost_metrics"] == {"cost_per_query": 0.01}
+    assert report["variants"][0]["cost"] == {"cost_per_query": 0.02}
+
+    md = _render_markdown(report)
+    assert "cost/query" in md
+    assert "$0.010000" in md
+    assert "$0.020000" in md
+
+
+def test_markdown_renders_dash_for_unpriced_base(tmp_path: Path):
+    queries = [QueryWithExpectedIds(query="hi", relevant_ids=("1",))]
+    base = _row("base", cost=None)
+    report = _build_report(
+        out_dir=tmp_path,
+        queries=queries,
+        base_row=base,
+        variant_rows=[],
+        derived=False,
+    )
+    assert report["cost_metrics"] is None
+    md = _render_markdown(report)
+    # the base decision row's cost cell is the em-dash placeholder
+    base_line = next(ln for ln in md.splitlines() if ln.startswith("| base "))
+    assert base_line.rstrip().endswith("| — |")
+
+
+def test_comparison_table_differentiates_providers_by_cost(tmp_path: Path):
+    pricing.reset_missing_warnings()
+    texts = ["a fairly typical search query about movies"] * 5
+    openai_cost = pricing.cost_per_query(
+        queries=texts,
+        provider="openai",
+        model="text-embedding-3-small",
+        reranker=None,
+        top_k=10,
+    )
+    voyage_cost = pricing.cost_per_query(
+        queries=texts, provider="voyage", model="voyage-3", reranker=None, top_k=10
+    )
+    assert openai_cost is not None and voyage_cost is not None
+    assert openai_cost != voyage_cost
+
+    queries = [QueryWithExpectedIds(query=t, relevant_ids=("1",)) for t in texts]
+    base = _row("base", cost={"cost_per_query": openai_cost})
+    variant = _row("voyage", cost={"cost_per_query": voyage_cost})
+    variant["overrides"] = {"embedding": {"provider": "voyage", "model": "voyage-3"}}
+    report = _build_report(
+        out_dir=tmp_path,
+        queries=queries,
+        base_row=base,
+        variant_rows=[variant],
+        derived=False,
+    )
+    md = _render_markdown(report)
+    base_cell = (
+        next(ln for ln in md.splitlines() if ln.startswith("| base ")).rsplit("|", 2)[1].strip()
+    )
+    voyage_cell = (
+        next(ln for ln in md.splitlines() if ln.startswith("| voyage ")).rsplit("|", 2)[1].strip()
+    )
+    assert base_cell.startswith("$") and voyage_cell.startswith("$")
+    assert base_cell != voyage_cell
+
+
+def test_unpriced_variant_dashes_and_warns_once(caplog):
+    pricing.reset_missing_warnings()
+    with caplog.at_level(logging.WARNING, logger="lib.pricing"):
+        c1 = pricing.cost_per_query(
+            queries=["x"], provider="acme", model="unknown-emb", reranker=None, top_k=10
+        )
+        c2 = pricing.cost_per_query(
+            queries=["y"], provider="acme", model="unknown-emb", reranker=None, top_k=10
+        )
+    assert c1 is None and c2 is None
+    line = _decision_row("acme-variant", {"recall@10": 0.1}, {"p95_ms": 1.0}, None, None)
+    assert line.rstrip().endswith("| — |")
+    warnings = [r for r in caplog.records if "unknown-emb" in r.getMessage()]
+    assert len(warnings) == 1

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,127 @@
+"""Unit tests for the per-query cost estimator (lib.pricing).
+
+Prices are read from the knowledge markdown tables, so these assertions
+track the advisory numbers seeded in:
+  - references/knowledge/dense_embedding_models.md
+  - references/knowledge/reranker_guide.md
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from lib import pricing
+
+
+def test_estimate_tokens_is_ceil_of_len_over_4():
+    assert pricing.estimate_tokens("") == 0
+    assert pricing.estimate_tokens("a") == 1
+    assert pricing.estimate_tokens("abcd") == 1
+    assert pricing.estimate_tokens("abcde") == 2
+    assert pricing.estimate_tokens("a" * 8) == 2
+
+
+def test_embedding_price_lookup_hit():
+    assert pricing.embedding_price_per_1m("openai", "text-embedding-3-small") == 0.02
+    assert pricing.embedding_price_per_1m("voyage", "voyage-3") == 0.06
+    # provider casing must not matter
+    assert pricing.embedding_price_per_1m("OpenAI", "text-embedding-3-small") == 0.02
+
+
+def test_embedding_price_lookup_miss_returns_none():
+    assert pricing.embedding_price_per_1m("openai", "no-such-model") is None
+    assert pricing.embedding_price_per_1m("acme", "whatever") is None
+
+
+def test_embedding_price_byom_wildcard_row():
+    # The `zilliz-byom | (user-chosen)` row is a provider-level wildcard
+    # priced 0 (self-hosted, no per-call API spend).
+    assert pricing.embedding_price_per_1m("zilliz-byom", "anything-at-all") == 0.0
+
+
+def test_reranker_price_lookup():
+    assert pricing.reranker_price_per_1k("cohere-rerank-3") == 2.0
+    assert pricing.reranker_price_per_1k("bge-reranker-v2-m3") == 0.0
+    assert pricing.reranker_price_per_1k("mystery-reranker") is None
+
+
+def test_cost_per_query_embed_only():
+    # estimate_tokens: "abcd"->1, "abcdefgh"->2  => mean 1.5 tokens/query
+    cost = pricing.cost_per_query(
+        queries=["abcd", "abcdefgh"],
+        provider="openai",
+        model="text-embedding-3-small",
+        reranker=None,
+        top_k=10,
+    )
+    assert cost == pytest.approx(1.5 / 1e6 * 0.02)
+
+
+def test_cost_per_query_with_reranker_adds_search_cost():
+    # rerank fan-out = top_k * 3 = 30 candidates => 30/1000 * 2.0 = 0.06
+    cost = pricing.cost_per_query(
+        queries=["abcd", "abcdefgh"],
+        provider="openai",
+        model="text-embedding-3-small",
+        reranker="cohere-rerank-3",
+        top_k=10,
+    )
+    assert cost == pytest.approx(1.5 / 1e6 * 0.02 + 30 / 1000 * 2.0)
+
+
+def test_cost_per_query_self_hosted_reranker_adds_nothing():
+    embed_only = pricing.cost_per_query(
+        queries=["hello world"],
+        provider="voyage",
+        model="voyage-3",
+        reranker=None,
+        top_k=10,
+    )
+    with_bge = pricing.cost_per_query(
+        queries=["hello world"],
+        provider="voyage",
+        model="voyage-3",
+        reranker="bge-reranker-v2-m3",
+        top_k=10,
+    )
+    assert embed_only == with_bge
+
+
+def test_cost_per_query_unpriced_embedding_returns_none():
+    assert (
+        pricing.cost_per_query(
+            queries=["abcd"],
+            provider="openai",
+            model="ghost-model",
+            reranker=None,
+            top_k=10,
+        )
+        is None
+    )
+
+
+def test_cost_per_query_unpriced_reranker_returns_none():
+    assert (
+        pricing.cost_per_query(
+            queries=["abcd"],
+            provider="openai",
+            model="text-embedding-3-small",
+            reranker="ghost-reranker",
+            top_k=10,
+        )
+        is None
+    )
+
+
+def test_unknown_model_warns_exactly_once(caplog):
+    pricing.reset_missing_warnings()
+    with caplog.at_level(logging.WARNING, logger="lib.pricing"):
+        pricing.cost_per_query(
+            queries=["abcd"], provider="openai", model="ghost-x", reranker=None, top_k=10
+        )
+        pricing.cost_per_query(
+            queries=["efgh"], provider="openai", model="ghost-x", reranker=None, top_k=10
+        )
+    matching = [r for r in caplog.records if "ghost-x" in r.getMessage()]
+    assert len(matching) == 1


### PR DESCRIPTION
Closes #10.

## Problem

`eval_report.md`'s decision table hardcoded the `cost/query` cell to `—` (placeholder in `_decision_row`), so comparison mode (`--compare variants.yaml`) could show recall/latency trade-offs between embedding providers but never the price trade-off — the column's whole reason for existing.

## Approach

- **Prices live in the knowledge markdown** so adding/repricing a model is a one-file edit:
  - `references/knowledge/dense_embedding_models.md` gains a `USD / 1M tokens` column
  - `references/knowledge/reranker_guide.md` gains a `USD / 1k searches` column
  - Self-hosted/BYOM rows priced `0`; both files note the prices are advisory estimates.
- **New `lib/pricing.py`** parses those tables and estimates per-query cost:
  - token estimate via the existing `len/4` heuristic (dependency-free, uniform across OpenAI/Voyage/Cohere/BYOM)
  - reranker priced per the `top_k * 3` candidate search fan-out (matches how Cohere Rerank actually bills; a deliberate, documented deviation from the issue's "tokens passed to reranker" wording)
  - missing model/adapter → returns `None` and logs **exactly one** deduplicated warning, never fails the run
- **Wired through** `_RowResult` → `_evaluate_single` → `_build_report` → `_decision_row`/`_render_markdown`: `eval_report.json` gains a per-row `cost`, `eval_report.md` renders a real USD value or `—`. Image/video plans keep `cost=None`.

## Acceptance (issue #10)

| Criterion | Status |
|---|---|
| Movies + ~25 derived queries shows non-`—` cost | ✅ proven at unit level (default `openai/text-embedding-3-small` yields a positive cost wired into the report); the live cluster run is gated behind the `cloud` marker |
| Comparison table shows different costs for two providers | ✅ `test_comparison_table_differentiates_providers_by_cost` |
| Adding a model = editing one markdown file | ✅ parser reads the knowledge tables; covered by `test_pricing.py` |

## Testing

- New `tests/test_pricing.py` + `tests/test_evaluate_cost.py` written test-first (RED→GREEN verified): 19 tests
- Full non-cloud suite: **323 passed, 1 skipped**
- `ruff check` + `ruff format --check` + `mypy` clean (enforced by the pre-commit hook on this commit)

## Note for reviewers

I did **not** execute a live end-to-end movies run (needs Milvus + API keys, runs under the `cloud` marker). Cost wiring is proven by unit tests; a sanity check against a live cluster before merge is worthwhile. Seeded prices are advisory estimates — verify against current provider pricing pages if exactness matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)