### PR TITLE
feat(launchpad): MCP server wrapping the six phases (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ npx skills add zilliztech/zilliz-launchpad --list
 
 Other agent flags include `-a copilot-cli`, `-a gemini-cli`, `-a cursor`, `-a opencode`, and `-a codex`.
 
+### MCP install path
+
+For non-skill-aware hosts (Cursor, Claude Desktop, generic MCP clients), the launchpad
+also ships an MCP server that exposes the same six phases as MCP tools. Install the
+`mcp` extra and launch the stdio server:
+
+```bash
+uv sync --extra mcp
+uv run python -m launchpad_mcp.server
+```
+
+See [`mcp/README.md`](mcp/README.md) for the full tool catalog, the structured error
+envelope, and a host-registration snippet.
+
 ### Preflight (optional)
 
 The skill drives these on demand, but you can do them ahead of time to skip a few conversational round-trips:

--- a/launchpad_mcp/__init__.py
+++ b/launchpad_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server wrapping the six zilliz-launchpad phases as MCP tools."""

--- a/launchpad_mcp/server.py
+++ b/launchpad_mcp/server.py
@@ -1,0 +1,250 @@
+"""FastMCP stdio server exposing the six zilliz-launchpad phases as tools.
+
+One tool per phase. Each tool's input matches the corresponding CLI flag
+surface (kebab-case CLI → snake_case JSON). Each tool returns
+``{"run_dir": str, "artifact": dict}`` where ``artifact`` is the JSON
+parsed from ``<run_dir>/<phase>.json``.
+
+Error envelope
+--------------
+
+On failure a tool raises a ``ToolError`` whose message is a JSON-encoded
+envelope. The envelope is exactly the dict produced by
+``LaunchpadError.to_dict()`` — i.e. ``{"code", "message", ...}`` — and is
+identical to the JSON the CLI prints to stderr today. Non-LaunchpadError
+exceptions are wrapped as ``{"code": "internal_error", "message": ...}``
+so the host never sees an opaque Python traceback.
+
+Hosts that want the structured envelope should ``json.loads`` the error
+text content. The unit/smoke tests below call the wrapper functions
+directly, so they observe the original ``LaunchpadError`` (or
+``InternalError``) before FastMCP serializes it.
+
+Run
+---
+
+::
+
+    python -m launchpad_mcp.server      # stdio transport
+    zilliz-launchpad-mcp                  # console script (if installed)
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from . import tools
+from .tools import InternalError, LaunchpadError  # re-exported below
+
+mcp = FastMCP("zilliz-launchpad")
+
+
+def _envelope_error(exc: BaseException) -> ToolError:
+    if isinstance(exc, tools.LaunchpadError):
+        payload = exc.to_dict()
+    else:
+        payload = {"code": "internal_error", "message": str(exc)}
+    return ToolError(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+def _invoke(fn: Callable[..., dict[str, Any]], /, **kwargs: Any) -> dict[str, Any]:
+    """Call a `tools.run_*` helper and convert any failure into a ToolError
+    whose message is the structured `{code, message, ...}` envelope.
+    """
+    try:
+        return fn(**kwargs)
+    except tools.LaunchpadError as exc:
+        raise _envelope_error(exc) from exc
+    except Exception as exc:  # noqa: BLE001  (we re-raise as ToolError)
+        raise _envelope_error(exc) from exc
+
+
+@mcp.tool(
+    name="collect",
+    description=(
+        "Phase 1 — analyze a sample file or directory and produce collect.json. "
+        "Starts a new run_dir (or appends to an existing one) and returns the "
+        "absolute run_dir path plus the collect.json contents. Call this first; "
+        "every later phase needs the run_dir returned here."
+    ),
+)
+def collect(
+    sample: str | None = None,
+    input_path: str | None = None,
+    run_dir: str | None = None,
+    with_thumbnails: bool | None = None,
+    thumbnail_cap_rows: int = 5000,
+    split_markdown_headings: bool = False,
+) -> dict[str, Any]:
+    """Phase 1: analyze sample data; mirrors `zilliz_ops.py collect`.
+
+    Pass exactly one of `sample` (bundled sample name) or `input_path`
+    (path to a JSONL/CSV/MD/PDF/TXT file or a directory of images / videos).
+    """
+    return _invoke(
+        tools.run_collect,
+        sample=sample,
+        input_path=input_path,
+        run_dir=run_dir,
+        with_thumbnails=with_thumbnails,
+        thumbnail_cap_rows=thumbnail_cap_rows,
+        split_markdown_headings=split_markdown_headings,
+    )
+
+
+@mcp.tool(
+    name="configure",
+    description=(
+        "Phase 2 — capture requirements and write configure.json. "
+        "Requires a run_dir created by `collect`. Overrides default knobs "
+        "(use_case, dataset_size, deployment_target, hybrid/reranker preferences, "
+        "and video sampling)."
+    ),
+)
+def configure(
+    run_dir: str,
+    from_json: str | None = None,
+    use_case: str | None = None,
+    dataset_size: int | None = None,
+    deployment_target: str | None = None,
+    hybrid_preference: str | None = None,
+    reranker_preference: str | None = None,
+    frame_interval_seconds: float | None = None,
+    max_frames_per_video: int | None = None,
+    sampling_strategy: str | None = None,
+    scene_threshold: float | None = None,
+) -> dict[str, Any]:
+    """Phase 2: capture requirements; mirrors `zilliz_ops.py configure`."""
+    return _invoke(
+        tools.run_configure,
+        run_dir=run_dir,
+        from_json=from_json,
+        use_case=use_case,
+        dataset_size=dataset_size,
+        deployment_target=deployment_target,
+        hybrid_preference=hybrid_preference,
+        reranker_preference=reranker_preference,
+        frame_interval_seconds=frame_interval_seconds,
+        max_frames_per_video=max_frames_per_video,
+        sampling_strategy=sampling_strategy,
+        scene_threshold=scene_threshold,
+    )
+
+
+@mcp.tool(
+    name="plan",
+    description=(
+        "Phase 3 — turn configure.json into plan.json + plan.md. "
+        "Requires a run_dir whose configure phase has already run. "
+        "Returns the parsed plan dict."
+    ),
+)
+def plan(run_dir: str) -> dict[str, Any]:
+    """Phase 3: produce plan artifacts; mirrors `zilliz_ops.py plan`."""
+    return _invoke(tools.run_plan, run_dir=run_dir)
+
+
+@mcp.tool(
+    name="execute",
+    description=(
+        "Phase 4 — apply the plan: create collection, build index, ingest, "
+        "and optionally start a local search-UI sidecar. Requires a run_dir "
+        "whose plan phase has already run. Set `append=True` together with "
+        "`input_path` to ingest additional rows into the existing collection."
+    ),
+)
+def execute(
+    run_dir: str,
+    sample: str | None = None,
+    input_path: str | None = None,
+    ui_port: int = 8000,
+    no_ui: bool = False,
+    frame_progress: bool = False,
+    append: bool = False,
+) -> dict[str, Any]:
+    """Phase 4: apply plan; mirrors `zilliz_ops.py execute`."""
+    return _invoke(
+        tools.run_execute,
+        run_dir=run_dir,
+        sample=sample,
+        input_path=input_path,
+        ui_port=ui_port,
+        no_ui=no_ui,
+        frame_progress=frame_progress,
+        append=append,
+    )
+
+
+@mcp.tool(
+    name="evaluate",
+    description=(
+        "Phase 5 — measure retrieval quality and write eval_report.{json,md}. "
+        "Requires a run_dir whose execute phase has produced an ingested "
+        "collection. Optionally compare against alternative plan variants "
+        "via `compare_path`."
+    ),
+)
+def evaluate(
+    run_dir: str,
+    qrels_path: str | None = None,
+    queries_path: str | None = None,
+    concurrency: int = 4,
+    judge_llm: str | None = None,
+    compare_path: str | None = None,
+    allow_large: bool = False,
+) -> dict[str, Any]:
+    """Phase 5: evaluate retrieval; mirrors `zilliz_ops.py evaluate`."""
+    return _invoke(
+        tools.run_evaluate,
+        run_dir=run_dir,
+        qrels_path=qrels_path,
+        queries_path=queries_path,
+        concurrency=concurrency,
+        judge_llm=judge_llm,
+        compare_path=compare_path,
+        allow_large=allow_large,
+    )
+
+
+@mcp.tool(
+    name="deploy",
+    description=(
+        "Phase 6 — provision or reuse a Zilliz Cloud cluster and migrate the "
+        "local collection into it. Requires a run_dir whose execute phase has "
+        "produced a local collection. Pass `cluster_id` to target an existing "
+        "cluster, or `create=True` (with `confirm=True`) to provision a new one."
+    ),
+)
+def deploy(
+    run_dir: str,
+    cluster_id: str | None = None,
+    create: bool = False,
+    confirm: bool = False,
+    stop_local: bool = False,
+) -> dict[str, Any]:
+    """Phase 6: deploy to Zilliz Cloud; mirrors `zilliz_ops.py deploy`."""
+    return _invoke(
+        tools.run_deploy,
+        run_dir=run_dir,
+        cluster_id=cluster_id,
+        create=create,
+        confirm=confirm,
+        stop_local=stop_local,
+    )
+
+
+def main() -> None:
+    """Console-script entrypoint: run the stdio MCP server."""
+    mcp.run("stdio")
+
+
+__all__ = ["mcp", "main", "InternalError", "LaunchpadError"]
+
+
+if __name__ == "__main__":
+    main()

--- a/launchpad_mcp/tools.py
+++ b/launchpad_mcp/tools.py
@@ -1,0 +1,220 @@
+"""Pure-Python wrappers around each launchpad phase.
+
+Each ``run_*`` here calls the matching ``run_<phase>`` helper that already
+exists in ``skills/zilliz-launchpad/scripts/lib/phases/<phase>.py`` — those
+helpers write the canonical ``<phase>.json`` artifact and return it as a
+``dict``. We do not touch ``lib/`` from this package.
+
+Phase → underlying callable (no Typer in the call path):
+  collect    → lib.phases.collect.run_collect
+  configure  → lib.phases.configure.run_configure
+  plan       → lib.phases.plan.run_plan
+  execute    → lib.phases.execute.run_execute  (+ run_execute_append when append=True)
+  evaluate   → lib.phases.evaluate.run_evaluate
+  deploy     → lib.phases.deploy.run_deploy
+
+Each wrapper returns ``{"run_dir": <abs path str>, "artifact": <dict>}``.
+
+All ``LaunchpadError`` subclasses propagate untouched so the server layer
+can attach ``err.to_dict()`` to the MCP tool error. Any other exception is
+wrapped in :class:`InternalError` so the host always sees a structured
+``{"code", "message"}`` envelope.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make the lib package importable regardless of CWD. pyproject already sets
+# this on the pytest pythonpath; we replicate it here so `python -m
+# launchpad_mcp.server` works from any directory.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "skills" / "zilliz-launchpad" / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from lib.errors import LaunchpadError  # noqa: E402
+from lib.phases import collect as _collect  # noqa: E402
+from lib.phases import configure as _configure  # noqa: E402
+from lib.phases import deploy as _deploy  # noqa: E402
+from lib.phases import evaluate as _evaluate  # noqa: E402
+from lib.phases import execute as _execute  # noqa: E402
+from lib.phases import plan as _plan  # noqa: E402
+from lib.run_dir import new_run_dir, resolve_run_dir  # noqa: E402
+
+__all__ = [
+    "InternalError",
+    "LaunchpadError",
+    "run_collect",
+    "run_configure",
+    "run_deploy",
+    "run_evaluate",
+    "run_execute",
+    "run_plan",
+]
+
+
+class InternalError(Exception):
+    """Catch-all wrapper for non-LaunchpadError exceptions."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"code": "internal_error", "message": self.message}
+
+
+class _MissingInputError(LaunchpadError):
+    code = "missing_input"
+
+
+def _result(run_dir: Path, artifact: dict[str, Any]) -> dict[str, Any]:
+    return {"run_dir": str(run_dir), "artifact": artifact}
+
+
+# --- Phase 1 ---------------------------------------------------------------
+
+
+def run_collect(
+    *,
+    sample: str | None = None,
+    input_path: str | None = None,
+    run_dir: str | None = None,
+    with_thumbnails: bool | None = None,
+    thumbnail_cap_rows: int = 5000,
+    split_markdown_headings: bool = False,
+) -> dict[str, Any]:
+    if sample is None and input_path is None:
+        raise _MissingInputError("Pass `sample` or `input_path`")
+    out = resolve_run_dir(run_dir) if run_dir else new_run_dir(label="collect")
+    artifact = _collect.run_collect(
+        input_path=input_path,
+        sample=sample,
+        out_dir=out,
+        with_thumbnails=with_thumbnails,
+        thumbnail_cap_rows=thumbnail_cap_rows,
+        split_markdown_headings=split_markdown_headings,
+    )
+    return _result(out, artifact)
+
+
+# --- Phase 2 ---------------------------------------------------------------
+
+
+def run_configure(
+    *,
+    run_dir: str,
+    from_json: str | None = None,
+    use_case: str | None = None,
+    dataset_size: int | None = None,
+    deployment_target: str | None = None,
+    hybrid_preference: str | None = None,
+    reranker_preference: str | None = None,
+    frame_interval_seconds: float | None = None,
+    max_frames_per_video: int | None = None,
+    sampling_strategy: str | None = None,
+    scene_threshold: float | None = None,
+) -> dict[str, Any]:
+    out = resolve_run_dir(run_dir)
+    overrides = {
+        "use_case": use_case,
+        "dataset_size": dataset_size,
+        "deployment_target": deployment_target,
+        "hybrid_preference": hybrid_preference,
+        "reranker_preference": reranker_preference,
+        "frame_interval_seconds": frame_interval_seconds,
+        "max_frames_per_video": max_frames_per_video,
+        "sampling_strategy": sampling_strategy,
+        "scene_threshold": scene_threshold,
+    }
+    artifact = _configure.run_configure(from_json=from_json, out_dir=out, overrides=overrides)
+    return _result(out, artifact)
+
+
+# --- Phase 3 ---------------------------------------------------------------
+
+
+def run_plan(*, run_dir: str) -> dict[str, Any]:
+    out = resolve_run_dir(run_dir)
+    artifact = _plan.run_plan(out_dir=out)
+    return _result(out, artifact)
+
+
+# --- Phase 4 ---------------------------------------------------------------
+
+
+def run_execute(
+    *,
+    run_dir: str,
+    sample: str | None = None,
+    input_path: str | None = None,
+    ui_port: int = 8000,
+    no_ui: bool = False,
+    frame_progress: bool = False,
+    append: bool = False,
+) -> dict[str, Any]:
+    out = resolve_run_dir(run_dir)
+    if append:
+        if input_path is None:
+            raise _MissingInputError("`append=True` requires `input_path`")
+        artifact = _execute.run_execute_append(out_dir=out, input_path=input_path)
+        return _result(out, artifact)
+    artifact = _execute.run_execute(
+        out_dir=out,
+        sample=sample,
+        input_path=input_path,
+        ui_port=ui_port,
+        start_ui=not no_ui,
+        frame_progress=frame_progress,
+    )
+    return _result(out, artifact)
+
+
+# --- Phase 5 ---------------------------------------------------------------
+
+
+def run_evaluate(
+    *,
+    run_dir: str,
+    qrels_path: str | None = None,
+    queries_path: str | None = None,
+    concurrency: int = 4,
+    judge_llm: str | None = None,
+    compare_path: str | None = None,
+    allow_large: bool = False,
+) -> dict[str, Any]:
+    out = resolve_run_dir(run_dir)
+    artifact = _evaluate.run_evaluate(
+        out_dir=out,
+        qrels_path=qrels_path,
+        queries_path=queries_path,
+        concurrency=concurrency,
+        judge_llm=judge_llm,
+        compare_path=compare_path,
+        allow_large=allow_large,
+    )
+    return _result(out, artifact)
+
+
+# --- Phase 6 ---------------------------------------------------------------
+
+
+def run_deploy(
+    *,
+    run_dir: str,
+    cluster_id: str | None = None,
+    create: bool = False,
+    confirm: bool = False,
+    stop_local: bool = False,
+) -> dict[str, Any]:
+    out = resolve_run_dir(run_dir)
+    artifact = _deploy.run_deploy(
+        out_dir=out,
+        cluster_id=cluster_id,
+        create=create,
+        confirm=confirm,
+        stop_local=stop_local,
+    )
+    return _result(out, artifact)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,12 +1,124 @@
-# MCP Path (Stub)
+# MCP Path
 
-This directory is a placeholder for a future MCP (Model Context Protocol) server
-that will expose the same phase commands exposed by `zilliz_ops.py` as MCP tools.
+zilliz-launchpad ships an MCP (Model Context Protocol) server that wraps the
+six CLI phases (`collect`, `configure`, `plan`, `execute`, `evaluate`, `deploy`)
+as MCP tools. Use this path when your host isn't agent-skill-aware (Cursor,
+Claude Desktop, generic MCP clients).
 
-The MVP ships only the Agent Skill path (see `skills/zilliz-launchpad/`).
-The CLI is designed so a thin MCP wrapper can be added here without touching
-`scripts/lib/` — each phase subcommand maps 1:1 to an MCP tool. Image
-collections (`use_case: image-search`, see issue #14) reuse the same
-six tools — no new MCP surface — once the wrapper lands (issue #11).
+The server lives in the [`launchpad_mcp`](../launchpad_mcp/) Python package.
+The directory name (`mcp/`) is reserved for this documentation entry point —
+the package itself is named `launchpad_mcp` so it doesn't shadow the official
+`mcp` SDK from PyPI.
 
-Not implemented in this change.
+## Install
+
+```bash
+uv sync --extra mcp
+```
+
+This adds the [`mcp`](https://pypi.org/project/mcp/) SDK. The Skill install
+path does not need this extra.
+
+## Launch
+
+```bash
+uv run python -m launchpad_mcp.server     # stdio transport
+```
+
+A console script `zilliz-launchpad-mcp` is also declared in `pyproject.toml`,
+available once the project is installed via a packaging tool that honors
+`[project.scripts]` (e.g. `pip install -e .[mcp]`).
+
+## Tools
+
+| Tool        | Phase | Returns                                                    |
+|-------------|-------|------------------------------------------------------------|
+| `collect`   | 1     | `{run_dir, artifact}` — `artifact` = parsed `collect.json` |
+| `configure` | 2     | `{run_dir, artifact}` — `artifact` = parsed `configure.json`|
+| `plan`      | 3     | `{run_dir, artifact}` — `artifact` = parsed `plan.json`    |
+| `execute`   | 4     | `{run_dir, artifact}` — `artifact` = execute report dict   |
+| `evaluate`  | 5     | `{run_dir, artifact}` — `artifact` = parsed `eval_report.json` |
+| `deploy`    | 6     | `{run_dir, artifact}` — `artifact` = deploy state dict     |
+
+Each tool's input schema mirrors the corresponding `python scripts/zilliz_ops.py
+<phase>` flag set (kebab-case CLI flag → snake_case JSON field). `collect`
+creates a new `run_dir` (or appends to an existing one if you pass `run_dir`);
+phases 2–6 require the `run_dir` returned by an earlier `collect` call.
+
+Run `zilliz-launchpad-mcp` and call `list_tools` from any MCP client to see
+the full parameter schemas.
+
+## Error envelope
+
+On failure a tool returns an MCP `CallToolResult` with `isError: true`. The
+text content is the standard CLI error envelope JSON, identical to what the
+CLI prints to stderr:
+
+```json
+{"code": "missing_credential", "message": "Required credential not set: OPENAI_API_KEY", "env_var": "OPENAI_API_KEY", "export_hint": "export OPENAI_API_KEY=<value>"}
+```
+
+Unexpected exceptions (anything that isn't a `LaunchpadError` subclass)
+surface with `code: "internal_error"` so hosts never see an opaque Python
+traceback.
+
+The FastMCP error content prefixes the envelope with `Error executing tool
+<name>: ` — host integrations should locate the first `{` and `json.loads`
+from there.
+
+## Worked example
+
+End-to-end `collect → configure → plan` over MCP (pseudocode for any MCP
+client):
+
+```python
+collect = await client.call_tool("collect", {"sample": "movies"})
+run_dir = collect.structuredContent["run_dir"]
+
+await client.call_tool("configure", {
+    "run_dir": run_dir,
+    "dataset_size": 20,
+    "deployment_target": "local-standalone",
+})
+
+plan = await client.call_tool("plan", {"run_dir": run_dir})
+print(plan.structuredContent["artifact"]["index"]["type"])  # → HNSW
+```
+
+The corresponding smoke test lives at
+[`tests/test_mcp_smoke.py`](../tests/test_mcp_smoke.py) and runs the same
+sequence through the in-process FastMCP client harness.
+
+## Host registration
+
+### Cursor / Claude Desktop
+
+Add an entry to your host's MCP config (`~/.cursor/mcp.json` for Cursor,
+`~/Library/Application Support/Claude/claude_desktop_config.json` for
+Claude Desktop on macOS):
+
+```json
+{
+  "mcpServers": {
+    "zilliz-launchpad": {
+      "command": "uv",
+      "args": ["run", "--project", "/abs/path/to/zilliz-launchpad",
+               "python", "-m", "launchpad_mcp.server"]
+    }
+  }
+}
+```
+
+Replace `/abs/path/to/zilliz-launchpad` with the absolute path of your
+checkout. Restart the host to pick up the server.
+
+## Boundary
+
+- The server does not modify anything under
+  `skills/zilliz-launchpad/scripts/lib/`; it imports the same `run_<phase>`
+  helpers the CLI calls.
+- Tool input schemas are maintained by hand and must stay in sync with the
+  CLI flags in `lib/phases/<phase>.py`. The smoke test catches drift for the
+  three deterministic phases; the others are exercised by their existing
+  unit/e2e tests.
+- Transport is stdio only. SSE / streamable-HTTP are out of scope for v1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ multimodal = [
 documents = [
     "pypdf>=4",
 ]
+mcp = [
+    "mcp>=1.0",
+]
+
+[project.scripts]
+zilliz-launchpad-mcp = "launchpad_mcp.server:main"
 
 [dependency-groups]
 dev = [
@@ -51,6 +57,7 @@ select = ["E", "F", "I", "W", "UP", "B", "SIM"]
 [tool.mypy]
 python_version = "3.11"
 strict = true
+mypy_path = "skills/zilliz-launchpad/scripts"
 exclude = ["skills/zilliz-launchpad/scripts/ui", "skills/zilliz-launchpad/scripts/runs", "tests/fixtures"]
 
 [[tool.mypy.overrides]]

--- a/tests/test_mcp_smoke.py
+++ b/tests/test_mcp_smoke.py
@@ -1,0 +1,155 @@
+"""Smoke test for the launchpad_mcp wrapper.
+
+Exercises the three deterministic phases (collect → configure → plan) over
+the in-process FastMCP client/server harness. Asserts that the per-tool
+response carries `run_dir` + `artifact`, that the artifact matches the
+JSON written to disk, and that the LaunchpadError → structured envelope
+mapping works.
+
+Skipped (not failed) when the optional `mcp` extra is not installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+mcp_sdk = pytest.importorskip("mcp", reason="install with: uv sync --extra mcp")
+
+import lib.run_dir as _run_dir_mod  # noqa: E402  (after importorskip)
+
+from launchpad_mcp import server as launchpad_server  # noqa: E402
+from launchpad_mcp import tools as launchpad_tools  # noqa: E402
+
+
+@pytest.fixture
+def isolated_runs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect new_run_dir/resolve_run_dir to tmp_path so phases don't touch
+    the developer's real runs/ directory.
+    """
+    root = tmp_path / "runs"
+    root.mkdir()
+    monkeypatch.setattr(_run_dir_mod, "_RUNS_ROOT", root)
+    return root
+
+
+def _parse_tool_result(result: Any) -> dict[str, Any]:
+    """Extract the structured payload from an MCP CallToolResult."""
+    if getattr(result, "structuredContent", None):
+        payload: dict[str, Any] = result.structuredContent
+        # FastMCP wraps non-model returns under a "result" key.
+        return payload.get("result", payload)  # type: ignore[no-any-return]
+    text: str = result.content[0].text
+    return json.loads(text)  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Direct wrapper tests (no MCP transport) — covers task 4.2 and 5.x.
+
+
+def test_collect_returns_envelope_on_missing_input(isolated_runs_root: Path) -> None:
+    """LaunchpadError surfaces with structured code/message."""
+    with pytest.raises(launchpad_tools.LaunchpadError) as exc_info:
+        launchpad_tools.run_collect()
+    envelope = exc_info.value.to_dict()
+    assert envelope["code"] == "missing_input"
+    assert "sample" in envelope["message"] or "input_path" in envelope["message"]
+
+
+def test_three_phase_pipeline_direct(isolated_runs_root: Path) -> None:
+    """collect → configure → plan via the wrapper functions directly."""
+    collect_result = launchpad_tools.run_collect(sample="movies")
+    run_dir = Path(collect_result["run_dir"])
+    assert run_dir.is_dir()
+    assert (run_dir / "collect.json").exists()
+    assert collect_result["artifact"] == json.loads(
+        (run_dir / "collect.json").read_text(encoding="utf-8")
+    )
+
+    configure_result = launchpad_tools.run_configure(
+        run_dir=str(run_dir),
+        dataset_size=20,
+        deployment_target="local-standalone",
+    )
+    assert configure_result["run_dir"] == str(run_dir)
+    assert (run_dir / "configure.json").exists()
+    assert configure_result["artifact"] == json.loads(
+        (run_dir / "configure.json").read_text(encoding="utf-8")
+    )
+
+    plan_result = launchpad_tools.run_plan(run_dir=str(run_dir))
+    assert plan_result["run_dir"] == str(run_dir)
+    assert (run_dir / "plan.json").exists()
+    assert plan_result["artifact"] == json.loads(
+        (run_dir / "plan.json").read_text(encoding="utf-8")
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end MCP transport test.
+
+
+async def test_three_phase_pipeline_over_mcp(isolated_runs_root: Path) -> None:
+    """Drive collect → configure → plan through the FastMCP harness."""
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    async with create_connected_server_and_client_session(
+        launchpad_server.mcp._mcp_server
+    ) as client:
+        tools_list = await client.list_tools()
+        names = [t.name for t in tools_list.tools]
+        assert names == ["collect", "configure", "plan", "execute", "evaluate", "deploy"]
+
+        collect_resp = await client.call_tool("collect", {"sample": "movies"})
+        assert not collect_resp.isError, collect_resp
+        collect_payload = _parse_tool_result(collect_resp)
+        run_dir = Path(collect_payload["run_dir"])
+        assert (run_dir / "collect.json").exists()
+        assert collect_payload["artifact"] == json.loads(
+            (run_dir / "collect.json").read_text(encoding="utf-8")
+        )
+
+        configure_resp = await client.call_tool(
+            "configure",
+            {
+                "run_dir": str(run_dir),
+                "dataset_size": 20,
+                "deployment_target": "local-standalone",
+            },
+        )
+        assert not configure_resp.isError, configure_resp
+        configure_payload = _parse_tool_result(configure_resp)
+        assert configure_payload["run_dir"] == str(run_dir)
+        assert configure_payload["artifact"] == json.loads(
+            (run_dir / "configure.json").read_text(encoding="utf-8")
+        )
+
+        plan_resp = await client.call_tool("plan", {"run_dir": str(run_dir)})
+        assert not plan_resp.isError, plan_resp
+        plan_payload = _parse_tool_result(plan_resp)
+        assert plan_payload["run_dir"] == str(run_dir)
+        assert plan_payload["artifact"] == json.loads(
+            (run_dir / "plan.json").read_text(encoding="utf-8")
+        )
+
+
+async def test_error_envelope_over_mcp(isolated_runs_root: Path) -> None:
+    """LaunchpadError → structured JSON envelope in the tool error content."""
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    async with create_connected_server_and_client_session(
+        launchpad_server.mcp._mcp_server
+    ) as client:
+        # collect with neither sample nor input_path → MissingInput envelope.
+        resp = await client.call_tool("collect", {})
+        assert resp.isError
+        text = resp.content[0].text  # type: ignore[union-attr]
+        # FastMCP prefixes the error string; the JSON envelope is appended.
+        # Extract the JSON suffix and assert its shape.
+        start = text.find("{")
+        envelope = json.loads(text[start:])
+        assert envelope["code"] == "missing_input"
+        assert "message" in envelope

--- a/tests/test_mcp_smoke.py
+++ b/tests/test_mcp_smoke.py
@@ -17,7 +17,13 @@ from typing import Any
 
 import pytest
 
-mcp_sdk = pytest.importorskip("mcp", reason="install with: uv sync --extra mcp")
+# Target a deep SDK module rather than the bare `mcp` package: the repo's
+# `mcp/` docs directory is picked up as a namespace package, so the bare
+# import succeeds even without the SDK installed and the skip never fires.
+pytest.importorskip(
+    "mcp.server.fastmcp",
+    reason="MCP SDK not installed — `uv sync --extra mcp`",
+)
 
 import lib.run_dir as _run_dir_mod  # noqa: E402  (after importorskip)
 

--- a/uv.lock
+++ b/uv.lock
@@ -229,6 +229,76 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +425,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -807,6 +936,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1202,6 +1340,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -2030,6 +2193,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2142,12 +2314,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2247,6 +2447,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -2651,6 +2870,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
 ]
 
 [[package]]
@@ -3424,6 +3656,9 @@ dependencies = [
 documents = [
     { name = "pypdf" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 multimodal = [
     { name = "av" },
     { name = "open-clip-torch" },
@@ -3446,6 +3681,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jsonschema", specifier = ">=4.23" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "open-clip-torch", marker = "extra == 'multimodal'", specifier = ">=2.24" },
     { name = "openai", specifier = ">=1.40" },
     { name = "pillow", specifier = ">=10.0" },
@@ -3458,7 +3694,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
     { name = "voyageai", specifier = ">=0.2" },
 ]
-provides-extras = ["multimodal", "documents"]
+provides-extras = ["multimodal", "documents", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Adds `launchpad_mcp/` — a FastMCP stdio server exposing the six launchpad phases (`collect`, `configure`, `plan`, `execute`, `evaluate`, `deploy`) as MCP tools, so non-skill-aware hosts (Cursor, Claude Desktop, generic MCP clients) can drive the workflow.
- Each tool's input mirrors the CLI flags; each returns `{run_dir, artifact}` where `artifact` is the parsed phase JSON. Errors round-trip as the existing `LaunchpadError.to_dict()` envelope (`{code, message, ...}`); non-LaunchpadError exceptions surface as `code: internal_error`.
- `lib/` is untouched — wrappers call the existing `run_<phase>` helpers directly. CLI `--help` is byte-identical.

## Notes

- Package is named `launchpad_mcp` (not `mcp/`) to avoid shadowing the official `mcp` SDK from PyPI. The `mcp/` directory stays as the user-facing doc entry point.
- `pyproject.toml` gains an `mcp` optional extra (`uv sync --extra mcp`) and a `zilliz-launchpad-mcp` console script. Also added `mypy_path` so the wrapper's `lib.*` imports type-check under strict mypy.
- Smoke test (`tests/test_mcp_smoke.py`) exercises `collect → configure → plan` both directly and over the in-process FastMCP client harness, plus the error-envelope path. Skips cleanly when the `mcp` extra is absent.

Closes #11.

## Test plan

- [x] `uv run ruff check .` ✓
- [x] `uv run ruff format --check .` ✓
- [x] `uv run mypy skills/zilliz-launchpad/scripts launchpad_mcp` ✓
- [x] `uv run pytest -q -m "not cloud and not e2e and not multimodal and not documents"` → 327 passed, 1 skipped
- [x] `python scripts/zilliz_ops.py --help` unchanged
- [ ] Manual: launch `zilliz-launchpad-mcp` from Cursor / Claude Desktop and confirm the six tools register

🤖 Generated with [Claude Code](https://claude.com/claude-code)