### PR TITLE
feat(launchpad): add --open-dashboard to Phase 6 deploy

### DIFF
--- a/skills/zilliz-launchpad/scripts/lib/phases/deploy.py
+++ b/skills/zilliz-launchpad/scripts/lib/phases/deploy.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import json
 import logging
+import webbrowser
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -345,6 +347,60 @@ def _stop_local_sidecar(run_dir: Path) -> None:
     pid_file.unlink(missing_ok=True)
 
 
+def _open_or_print(
+    url: str,
+    *,
+    opener: Callable[[str], bool] = webbrowser.open,
+    echo: Callable[[str], Any] = typer.echo,
+) -> None:
+    """Try to open ``url`` in the user's browser; print it on any failure.
+
+    A browser hiccup must never turn a successful deploy into a failed run,
+    so exceptions and a ``False`` return both fall through to a clear print.
+    """
+    opened = False
+    try:
+        opened = bool(opener(url))
+    except Exception as exc:
+        logger.warning("webbrowser.open failed: %s", exc)
+    if not opened:
+        echo(f"open this in your browser: {url}")
+
+
+def _emit_deploy_summary(
+    report: dict[str, Any],
+    out_dir: Path,
+    *,
+    open_dashboard: bool,
+    opener: Callable[[str], bool] = webbrowser.open,
+    echo: Callable[[str], Any] = typer.echo,
+) -> None:
+    echo(f"run-dir: {out_dir}")
+    echo(f"cluster: {report['cluster_id']} ({report['cluster_uri']})")
+    echo(f"collection: {report['collection_name']}")
+    echo(
+        f"ingest: {report['ingest_mode']} "
+        f"({report['ingest_row_count']} rows, status={report['ingest_status']})"
+    )
+    obs = report.get("observability") or {}
+    grafana = obs.get("grafana_dashboard")
+    prometheus = obs.get("prometheus_url")
+    if grafana:
+        echo(f"dashboard: {grafana}")
+    if prometheus:
+        echo(f"prometheus: {prometheus}")
+    echo(f"deploy.json: {out_dir / 'deploy.json'}")
+
+    if not open_dashboard:
+        return
+    if grafana:
+        _open_or_print(grafana, opener=opener, echo=echo)
+    else:
+        echo("no Grafana dashboard available for this deploy target")
+        if prometheus:
+            echo(f"prometheus metrics: {prometheus}")
+
+
 def register(app: typer.Typer) -> None:
     """Attach the Phase 6 ``deploy`` subcommand to the shared app."""
 
@@ -363,6 +419,11 @@ def register(app: typer.Typer) -> None:
         stop_local: bool = typer.Option(
             False, "--stop-local", help="Stop the Phase 4 local UI sidecar after deploy"
         ),
+        open_dashboard: bool = typer.Option(
+            False,
+            "--open-dashboard",
+            help="Open the Grafana dashboard in your default browser after a successful deploy",
+        ),
     ) -> None:
         """Phase 6 — promote the Execute run to Zilliz Cloud."""
         out = resolve_run_dir(run_dir)
@@ -376,16 +437,4 @@ def register(app: typer.Typer) -> None:
             )
         except LaunchpadError as e:
             _cli_fail(e)
-        typer.echo(f"run-dir: {out}")
-        typer.echo(f"cluster: {report['cluster_id']} ({report['cluster_uri']})")
-        typer.echo(f"collection: {report['collection_name']}")
-        typer.echo(
-            f"ingest: {report['ingest_mode']} "
-            f"({report['ingest_row_count']} rows, status={report['ingest_status']})"
-        )
-        obs = report.get("observability") or {}
-        if obs.get("grafana_dashboard"):
-            typer.echo(f"grafana: {obs['grafana_dashboard']}")
-        if obs.get("prometheus_url"):
-            typer.echo(f"prometheus: {obs['prometheus_url']}")
-        typer.echo(f"deploy.json: {out / 'deploy.json'}")
+        _emit_deploy_summary(report, out, open_dashboard=open_dashboard)

--- a/tests/test_phase_deploy.py
+++ b/tests/test_phase_deploy.py
@@ -10,7 +10,12 @@ from pathlib import Path
 
 import pytest
 from lib.errors import DestructiveWithoutConfirmError, InvalidProfileError
-from lib.phases.deploy import _resolve_cluster_precedence, _write_observability_snapshot
+from lib.phases.deploy import (
+    _emit_deploy_summary,
+    _open_or_print,
+    _resolve_cluster_precedence,
+    _write_observability_snapshot,
+)
 
 
 def test_precedence_rejects_cluster_id_and_create_together():
@@ -111,6 +116,118 @@ def test_observability_snapshot_extends_existing_file(tmp_path: Path):
     assert data["deploy_snapshots"][1]["cluster_id"] == "c-new"
     # latency_samples from an earlier evaluate run must survive
     assert data["latency_samples"] == [{"source": "evaluate"}]
+
+
+# --- --open-dashboard ----------------------------------------------------
+
+
+def _report(
+    *,
+    grafana: str | None = "https://grafana.example/dashboard/abc",
+    prometheus: str | None = None,
+) -> dict:
+    return {
+        "cluster_id": "c-1",
+        "cluster_uri": "https://in03.api.gcp.zillizcloud.com",
+        "collection_name": "coll",
+        "ingest_mode": "client",
+        "ingest_row_count": 100,
+        "ingest_status": "complete",
+        "observability": {
+            "grafana_dashboard": grafana,
+            "prometheus_url": prometheus,
+        },
+    }
+
+
+def test_open_dashboard_invokes_opener(tmp_path: Path):
+    calls: list[str] = []
+    lines: list[str] = []
+
+    _emit_deploy_summary(
+        _report(),
+        tmp_path,
+        open_dashboard=True,
+        opener=lambda url: calls.append(url) or True,
+        echo=lines.append,
+    )
+    assert calls == ["https://grafana.example/dashboard/abc"]
+    assert any(line == "dashboard: https://grafana.example/dashboard/abc" for line in lines)
+
+
+def test_open_dashboard_headless_falls_back_to_print(tmp_path: Path):
+    lines: list[str] = []
+    _emit_deploy_summary(
+        _report(),
+        tmp_path,
+        open_dashboard=True,
+        opener=lambda _url: False,
+        echo=lines.append,
+    )
+    assert any(
+        line == "open this in your browser: https://grafana.example/dashboard/abc" for line in lines
+    )
+
+
+def test_open_dashboard_no_grafana_prints_prometheus(tmp_path: Path):
+    calls: list[str] = []
+    lines: list[str] = []
+    _emit_deploy_summary(
+        _report(grafana=None, prometheus="http://localhost:9091/metrics"),
+        tmp_path,
+        open_dashboard=True,
+        opener=lambda url: calls.append(url) or True,
+        echo=lines.append,
+    )
+    assert calls == []  # opener never called when no Grafana URL
+    assert any("no Grafana dashboard available" in line for line in lines)
+    assert any(line == "prometheus metrics: http://localhost:9091/metrics" for line in lines)
+
+
+def test_open_dashboard_opener_exception_does_not_fail(tmp_path: Path):
+    lines: list[str] = []
+
+    def boom(_url: str) -> bool:
+        raise RuntimeError("no display configured")
+
+    _emit_deploy_summary(
+        _report(),
+        tmp_path,
+        open_dashboard=True,
+        opener=boom,
+        echo=lines.append,
+    )
+    # Falls through to the print fallback
+    assert any(
+        line == "open this in your browser: https://grafana.example/dashboard/abc" for line in lines
+    )
+
+
+def test_summary_without_flag_prints_dashboard_line_but_does_not_open(tmp_path: Path):
+    calls: list[str] = []
+    lines: list[str] = []
+    _emit_deploy_summary(
+        _report(),
+        tmp_path,
+        open_dashboard=False,
+        opener=lambda url: calls.append(url) or True,
+        echo=lines.append,
+    )
+    assert calls == []
+    # Grafana URL still shown on its own line so user can click it
+    assert any(line == "dashboard: https://grafana.example/dashboard/abc" for line in lines)
+
+
+def test_open_or_print_warns_and_prints_on_exception(caplog):
+    lines: list[str] = []
+
+    def boom(_url: str) -> bool:
+        raise RuntimeError("nope")
+
+    with caplog.at_level("WARNING"):
+        _open_or_print("https://x.example", opener=boom, echo=lines.append)
+    assert lines == ["open this in your browser: https://x.example"]
+    assert any("webbrowser.open failed" in rec.message for rec in caplog.records)
 
 
 def test_observability_snapshot_recovers_from_corrupt_file(tmp_path: Path):


### PR DESCRIPTION
Closes #13.

## Summary

- New `deploy --open-dashboard` flag opens `observability.grafana_dashboard` in the user's default browser via `webbrowser.open` (stdlib, cross-platform) after a successful run.
- Robust headless fallback: `webbrowser.open` returning `False` or raising any exception degrades to a clear `open this in your browser: <url>` print, never failing the deploy.
- When the target has no Grafana URL (Standalone), the flag becomes a no-op with an informative notice plus the Prometheus URL if available.
- The Grafana URL is always echoed on its own `dashboard: <url>` line in the success summary, even without the flag, so it is impossible to miss.

## Implementation notes

- All open/print logic lives in two small helpers in `deploy.py` (`_open_or_print`, `_emit_deploy_summary`) so `run_deploy` stays pure and library-callable.
- No new dependencies — `webbrowser` is stdlib.
- No changes to `deploy.json` schema.

## Test plan

- [x] `pytest tests/test_phase_deploy.py -q` → 15 passed (6 new tests covering: flag invokes opener, headless fallback, null Grafana → Prometheus print, opener raises, default-off behavior, warning log)
- [x] Full suite `pytest -q` → 361 passed, 5 skipped
- [x] `ruff check` and `mypy` clean on touched files
- [x] Eyeballed the success-summary formatting via a direct `_emit_deploy_summary` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)